### PR TITLE
Support circle and text primitives

### DIFF
--- a/examples/converters/kitti/src/converters/tracklets-converter.js
+++ b/examples/converters/kitti/src/converters/tracklets-converter.js
@@ -16,7 +16,7 @@ export class TrackletsDataSource {
 
     // laser scanner relative to GPS position
     // http://www.cvlibs.net/datasets/kitti/setup.php
-    this.TRANSFORM = {
+    this.FIXTURE_TRANSFORM_POSE = {
       x: 0.81,
       y: -0.32,
       z: 1.73
@@ -135,7 +135,7 @@ export class TrackletsDataSource {
         fillColor: '#D6A00080',
         strokeColor: '#D6A000'
       })
-      .pose(this.TRANSFORM)
+      .pose(this.FIXTURE_TRANSFORM_POSE)
 
       .stream(this.TRACKLETS_TRACKING_POINT)
       .category('primitive')
@@ -144,7 +144,7 @@ export class TrackletsDataSource {
         radius: 0.2,
         fillColor: '#FFFF00'
       })
-      .pose(this.TRANSFORM)
+      .pose(this.FIXTURE_TRANSFORM_POSE)
 
       .stream(this.TRACKLETS_LABEL)
       .category('primitive')
@@ -153,7 +153,7 @@ export class TrackletsDataSource {
         size: 18,
         fillColor: '#0040E0'
       })
-      .pose(this.TRANSFORM)
+      .pose(this.FIXTURE_TRANSFORM_POSE)
 
       .stream(this.TRACKLETS_TRAJECTORY)
       .category('primitive')
@@ -163,7 +163,7 @@ export class TrackletsDataSource {
         strokeWidth: 0.3,
         strokeWidthMinPixels: 1
       })
-      .pose(this.TRANSFORM);
+      .pose(this.FIXTURE_TRANSFORM_POSE);
   }
 
   _convertFrame(frame_index) {

--- a/modules/core/src/components/log-viewer.js
+++ b/modules/core/src/components/log-viewer.js
@@ -144,7 +144,8 @@ class Core3DViewer extends PureComponent {
               style: styleParser.getStylesheet(streamName),
               objectStates: {},
 
-              // Hack: draw extruded polygons last to defeat depth test
+              // Hack: draw extruded polygons last to defeat depth test when rendering translucent objects
+              // This is not used by deck.gl, only used in this function to sort the layers
               zIndex: streamMetadata.type === 'polygon' ? 2 : 0,
 
               // Selection props (app defined, not used by deck.gl)

--- a/modules/core/src/layers/xviz-layer.js
+++ b/modules/core/src/layers/xviz-layer.js
@@ -262,6 +262,7 @@ export default class XvizLayer extends CompositeLayer {
             ...layerProps,
             id: 'scatterplot',
             data,
+            // `vertices` is used xviz V1 and `center` is used by xviz V2
             getPosition: f => f.vertices || f.center,
             updateTriggers: deepExtend(updateTriggers, {
               getColor: {useSemanticColor: this.props.useSemanticColor}


### PR DESCRIPTION
This PR depends on https://github.com/uber/xviz/pull/39

<img width="838" alt="screen shot 2018-08-30 at 3 01 48 pm" src="https://user-images.githubusercontent.com/2059298/44882482-548e7a80-ac68-11e8-8c52-ee496445d49e.png">

- Add circle and text streams to KITTI example
- Handle circle and text types in LogViewer