### PR TITLE
Fix first frame not displayed bug

### DIFF
--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -122,6 +122,8 @@ export default class XVIZLoaderInterface {
   getCurrentFrame = createSelector(
     this,
     [this.getLogSynchronizer, this.getMetadata, this.getCurrentTime, this.getStreams],
+    // `getStreams` is only needed to trigger recomputation.
+    // The logSynchronizer has access to the streamBuffer.
     (logSynchronizer, metadata, timestamp) => {
       if (logSynchronizer && metadata && Number.isFinite(timestamp)) {
         logSynchronizer.setTime(timestamp);


### PR DESCRIPTION
The `getCurrentFrame` selector needs to be re-triggered when new frames arrive.