### PR TITLE
Remove support for deprecated stylesheet dictionary structure

### DIFF
--- a/docs/api-reference/log-viewer.md
+++ b/docs/api-reference/log-viewer.md
@@ -28,7 +28,7 @@ A [Mapbox style](https://www.mapbox.com/mapbox-gl-js/api/#map) to render the bas
 
 ##### `xvizStyles` (Object, optional)
 
-Overrie the XVIZ styles. If supplied, will be deep-merged with the styles in the log metadata.
+Override the XVIZ styles. If supplied, will be deep-merged with the styles in the log metadata.
 
 For more information, see [XVIZ styling specification](https://github.com/uber/xviz/blob/master/docs/protocol-schema/style-specification.md).
 

--- a/modules/core/src/utils/style.js
+++ b/modules/core/src/utils/style.js
@@ -1,4 +1,11 @@
-// Deep merges two XVIZ style objects
+/**
+ * Deep merges two XVIZ style objects.
+ * The primary style stream rules will take precedence over the secondary rules.
+ *
+ * @param style1 {object} Secondary stylesheet
+ * @param style2 {object} Primary stylesheet
+ * @returns {object} Merged styleheet with Primary rules taking precedence
+ */
 export function mergeXvizStyles(style1, style2) {
   if (!style1) {
     return style2 || {};
@@ -11,19 +18,12 @@ export function mergeXvizStyles(style1, style2) {
 
   for (const streamName in style2) {
     if (mergedStyles[streamName]) {
-      const rules1 = normalizeXvizStyleRules(style1[streamName]);
-      const rules2 = normalizeXvizStyleRules(style2[streamName]);
+      const rules1 = style1[streamName];
+      const rules2 = style2[streamName];
       mergedStyles[streamName] = rules1.concat(rules2);
     } else {
       mergedStyles[streamName] = style2[streamName];
     }
   }
   return mergedStyles;
-}
-
-function normalizeXvizStyleRules(rules) {
-  return Array.isArray(rules)
-    ? rules
-    : // Backward compatibility - support classname to style map
-      Object.keys(rules).map(classname => ({...rules[classname], class: classname}));
 }

--- a/test/modules/core/utils/index.js
+++ b/test/modules/core/utils/index.js
@@ -2,3 +2,4 @@ import 'streetscape.gl';
 
 import './buffer-range.spec';
 import './metrics-helper.spec';
+import './style.spec';

--- a/test/modules/core/utils/style.spec.js
+++ b/test/modules/core/utils/style.spec.js
@@ -1,0 +1,86 @@
+import test from 'tape';
+
+import {mergeXvizStyles} from 'streetscape.gl/utils/style';
+
+test('style#mergeXvizStyles precedence order', t => {
+  const style1 = {
+    '/foo': [
+      {
+        class: 'one',
+        color: '#111111'
+      }
+    ],
+    '/bar': [
+      {
+        class: 'two',
+        color: '#222222'
+      }
+    ]
+  };
+
+  const style2 = {
+    '/foo': [
+      {
+        class: 'one',
+        color: '#333333',
+        fill: true
+      }
+    ],
+    '/bar': [
+      {
+        class: 'two',
+        color: '#444444',
+        fill: true
+      }
+    ],
+    '/baz': [
+      {
+        class: 'three',
+        color: '#555555',
+        fill: true
+      }
+    ]
+  };
+
+  const mergedStyles = mergeXvizStyles(style1, style2);
+
+  // style1 entries come first, because in XVIZ Styling
+  // latter rule definitions overrule earler ones.
+  // This is validating that style2 rules are defined
+  // after style1
+  const expected = {
+    '/foo': [
+      {
+        class: 'one',
+        color: '#111111'
+      },
+      {
+        class: 'one',
+        color: '#333333',
+        fill: true
+      }
+    ],
+    '/bar': [
+      {
+        class: 'two',
+        color: '#222222'
+      },
+      {
+        class: 'two',
+        color: '#444444',
+        fill: true
+      }
+    ],
+    '/baz': [
+      {
+        class: 'three',
+        color: '#555555',
+        fill: true
+      }
+    ]
+  };
+
+  t.deepEqual(mergedStyles, expected, `Merged XVIZ styles should match expected.`);
+
+  t.end();
+});


### PR DESCRIPTION
- document the order of style rules when merging
- add test case for mergeXvizStyle