### PR TITLE
Update XVIZ server to use frame index file if present

### DIFF
--- a/examples/converters/kitti/src/transform.js
+++ b/examples/converters/kitti/src/transform.js
@@ -55,6 +55,8 @@ module.exports = async function main(args) {
     xvizWriter.writeFrame(outputDir, i, xvizFrame, writerOptions);
   }
 
+  xvizWriter.writeFrameIndex(outputDir);
+
   const end = Date.now();
   console.log(`Generate ${limit} frames in ${end - start}s`); // eslint-disable-line
 };


### PR DESCRIPTION
- The index file will be used to avoid manually iterating over frames
  to obtain their timestamp