### PR TITLE
Fix website demo data access

### DIFF
--- a/website/src/static/kitti
+++ b/website/src/static/kitti
@@ -1,0 +1,1 @@
+../../../../xviz/data/generated/kitti


### PR DESCRIPTION
The demo looks for the data in `status/kitti` but with the
move of the server and data generator to the XVIZ repo that
data is not setup anymore.  So we symlink it in.