### PR TITLE
Update to Yarn 1.10 to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:8.12.0
 
 WORKDIR /streetscape
 
-RUN yarn global add yarn@1.7.0
+RUN yarn global add yarn@1.10.0
 
 WORKDIR /streetscape
 ENV PATH /streetscape/node_modules/.bin:$PATH

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -39,7 +39,7 @@
   "engines": {
     "node": ">= 8",
     "npm": ">= 5",
-    "yarn": ">= 1.7.0"
+    "yarn": ">= 1.10.0"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "engines": {
     "node": ">= 8",
     "npm": ">= 5",
-    "yarn": ">= 1.7.0"
+    "yarn": ">= 1.10.0"
   },
   "pre-commit": [
     "test-fast"


### PR DESCRIPTION
XVIZ is on 1.10 to keep the lockfile integrity information.