### PR TITLE
Update to be compatible with standard XVIZ 2 servers only

### DIFF
--- a/modules/core/src/loaders/xviz-controller-v2.js
+++ b/modules/core/src/loaders/xviz-controller-v2.js
@@ -20,27 +20,28 @@ export default class XVIZControllerV2 {
   constructor(socket) {
     assert(socket, 'XVIZ socket');
     this.socket = socket;
+    this.transformCounter = 0;
   }
 
-  _send(message) {
-    this.socket.send(JSON.stringify(message));
+  _send(type, message) {
+    const msg = {type: `xviz/${type}`, data: message};
+    this.socket.send(JSON.stringify(msg));
   }
 
-  open({timestamp, duration}) {
-    const msg = {type: 'open', duration};
-    if (timestamp) {
-      msg.timestamp = timestamp;
+  transformLog({startTimestamp, endTimestamp}) {
+    const msg = {};
+    if (startTimestamp) {
+      msg.start_timestamp = startTimestamp; // eslint-disable-line camelcase
     }
-    this._send(msg);
-  }
 
-  metadata() {
-    const msg = {type: 'metadata'};
-    this._send(msg);
-  }
+    if (endTimestamp) {
+      msg.end_timestamp = endTimestamp; // eslint-disable-line camelcase
+    }
 
-  play({timestamp, duration}) {
-    const msg = {type: 'play', timestamp, duration};
-    this._send(msg);
+    // Add in a sequential id
+    msg.id = `${this.transformCounter}`;
+    this.transformCounter++;
+
+    this._send('transform_log', msg);
   }
 }

--- a/test/modules/core/loaders/xviz-stream-loader.spec.js
+++ b/test/modules/core/loaders/xviz-stream-loader.spec.js
@@ -59,18 +59,14 @@ test('XVIZStreamLoader#connect, seek', t => {
       'http://localhost:3000?log=test_log&profile=default',
       'socket connected to correct url'
     );
-    t.deepEquals(
-      socket.flush(),
-      [{type: 'open', duration: 30}, {type: 'metadata'}],
-      'initial hand shake'
-    );
+    t.deepEquals(socket.flush(), [], 'No data till metadata');
 
     // Mock metadata
     loader._onWSMessage({type: LOG_STREAM_MESSAGE.METADATA, start_time: 1000, end_time: 1030});
     t.deepEquals(
       socket.flush(),
-      [{type: 'play', duration: 10, timestamp: 1000}],
-      'seek: update with correct parameters'
+      [{type: 'xviz/transform_log', data: {start_timestamp: 1000, end_timestamp: 1010, id: '0'}}],
+      'transform_log: update with correct parameters'
     );
 
     loader.seek(1005);
@@ -79,7 +75,7 @@ test('XVIZStreamLoader#connect, seek', t => {
     loader.seek(1012);
     t.deepEquals(
       socket.flush(),
-      [{type: 'play', duration: 10, timestamp: 1007}],
+      [{type: 'xviz/transform_log', data: {start_timestamp: 1007, end_timestamp: 1017, id: '1'}}],
       'seek: update with correct parameters'
     );
 
@@ -91,7 +87,7 @@ test('XVIZStreamLoader#connect, seek', t => {
     loader.seek(1001);
     t.deepEquals(
       socket.flush(),
-      [{type: 'play', duration: 7, timestamp: 1000}],
+      [{type: 'xviz/transform_log', data: {start_timestamp: 1000, end_timestamp: 1007, id: '2'}}],
       'seek: update with correct parameters'
     );
 


### PR DESCRIPTION
In the standard protocol you open the connection, wait for metadata,
then send your `transform_log` request.  There are no separate `open`,
or `play` commands.  The transform command is also a direct range
instead of start + duration.

For compatibility this needs uber/xviz#240