### PR TITLE
Work when missing stream metadata

### DIFF
--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -36,6 +36,10 @@ const DEFAULT_CAR = {
 
 const noop = () => {};
 
+function getStreamMetadata(metadata, streamName) {
+  return (metadata && metadata.streams && metadata.streams[streamName]) || {};
+}
+
 export default class Core3DViewer extends PureComponent {
   static propTypes = {
     // Props from loader
@@ -172,7 +176,9 @@ export default class Core3DViewer extends PureComponent {
     const featuresAndFutures = new Set(
       Object.keys(streams)
         .concat(Object.keys(lookAheads))
-        .filter(streamName => streamFilter(streamName) && streamSettings[streamName])
+        .filter(
+          streamName => streamFilter(streamName) && (!streamSettings || streamSettings[streamName])
+        )
     );
 
     return [
@@ -197,7 +203,7 @@ export default class Core3DViewer extends PureComponent {
           // Check lookAheads first because it will contain the selected futures
           // while streams would contain the full futures array
           const stream = lookAheads[streamName] || streams[streamName];
-          const streamMetadata = metadata.streams[streamName];
+          const streamMetadata = getStreamMetadata(metadata, streamName);
           const coordinateProps = resolveCoordinateTransform(
             frame,
             streamMetadata,
@@ -220,7 +226,7 @@ export default class Core3DViewer extends PureComponent {
 
               // Hack: draw extruded polygons last to defeat depth test when rendering translucent objects
               // This is not used by deck.gl, only used in this function to sort the layers
-              zIndex: streamMetadata.primitive_type === 'polygon' ? 2 : 0,
+              zIndex: streamMetadata && streamMetadata.primitive_type === 'polygon' ? 2 : 0,
 
               // Selection props (app defined, not used by deck.gl)
               streamName
@@ -254,7 +260,7 @@ export default class Core3DViewer extends PureComponent {
         if (props.streamName) {
           // Use log data
           const stream = streams[props.streamName];
-          const streamMetadata = metadata.streams[props.streamName];
+          const streamMetadata = getStreamMetadata(metadata, props.streamName);
           Object.assign(
             props,
             resolveCoordinateTransform(frame, streamMetadata, getTransformMatrix),

--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -212,7 +212,9 @@ export default class XVIZLoaderInterface {
 
   _setMetadata(metadata) {
     this.set('metadata', metadata);
-    this.set('streamSettings', metadata.streams);
+    if (metadata.streams && Object.keys(metadata.streams) > 0) {
+      this.set('streamSettings', metadata.streams);
+    }
     const timestamp = this.get('timestamp');
     const newTimestamp = Number.isFinite(timestamp) ? timestamp : metadata.start_time;
     this.seek(newTimestamp);


### PR DESCRIPTION
- Only set 'streamSettings' if we have actual stream metadata
- Protect access to metadata.streams object