### PR TITLE
Fix various stream filtering issues

### DIFF
--- a/docs/api-reference/log-viewer.md
+++ b/docs/api-reference/log-viewer.md
@@ -33,18 +33,22 @@ For more information, see
 
 Defines the car asset. May contain the following fields:
 
-- `mesh` (Object|Promise) - a descriptor of the car model. If supplied, must contain the following fields:
+- `mesh` (Object|Promise) - a descriptor of the car model. If supplied, must contain the following
+  fields:
   - `indices` (Uint16Array|Uint32Array)
   - `positions` (Float32Array)
   - `normals` (Float32Array)
   - `texCoords` (Float32Array)
 - `texture` (String) - path to an image file that is the texture for the model
-- `scale` (Number|[Number, Number, Number]) - size scale of the car relative to the mesh. If an array is supplied, it is interpreted as `[scale_x, scale_y, scale_z]`.
+- `scale` (Number|[Number, Number, Number]) - size scale of the car relative to the mesh. If an
+  array is supplied, it is interpreted as `[scale_x, scale_y, scale_z]`.
 - `origin` ([Number, Number, Number]) - offset of the model origin in meters.
 
-The x axis points from the front to the back of the car, the y axis points from the left to the right of the car, and the z axis is up.
+The x axis points from the front to the back of the car, the y axis points from the left to the
+right of the car, and the z axis is up.
 
-If not specified, `mesh` defaults to a nondescript car shape that measures 1m x 1m x 1m. To use the default mesh, one can set `scale` to `[length, width, height]` of the car in meters.
+If not specified, `mesh` defaults to a nondescript car shape that measures 1m x 1m x 1m. To use the
+default mesh, one can set `scale` to `[length, width, height]` of the car in meters.
 
 ##### streamFilter (Array|String|Object|Function, optional)
 

--- a/docs/api-reference/xviz-loader-interface.md
+++ b/docs/api-reference/xviz-loader-interface.md
@@ -117,12 +117,6 @@ Returns all
 [time_series](https://github.com/uber/xviz/blob/master/docs/protocol-schema/core-types.md#stream-set)
 streams.
 
-##### getImageFrames()
-
-Returns all
-[image](https://github.com/uber/xviz/blob/master/docs/protocol-schema/geometry-primitives.md#image-primitive)
-streams.
-
 ## Implementations
 
 - [XVIZStreamLoader](/docs/api-reference/xviz-stream-loader.md)

--- a/docs/api-reference/xviz-video-component.md
+++ b/docs/api-reference/xviz-video-component.md
@@ -25,7 +25,7 @@ Custom CSS overrides.
 
 - `wrapper` (Object|Function) - the wrapper component.
 - `selector` (Object) - See
-[styling Dropdown](https://github.com/uber-web/monochrome/blob/master/src/shared/dropdown/README.md#styling).
+  [styling Dropdown](https://github.com/uber-web/monochrome/blob/master/src/shared/dropdown/README.md#styling).
 
 ### Declarative UI Component Descriptor
 
@@ -44,6 +44,10 @@ with a Redux store.
 
 The current playback position of the log.
 
-##### imageFrames (Object)
+##### streamMetadata (Object)
 
-An object mapping from stream names to the loaded image frames.
+A map from stream names to their metadata.
+
+##### streams (Object)
+
+Currently loaded streams.

--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -138,7 +138,6 @@ export default class Core3DViewer extends PureComponent {
       showTooltip,
       objectStates,
       customLayers,
-      streamSettings,
       getTransformMatrix
     } = this.props;
     if (!frame || !metadata) {
@@ -152,9 +151,7 @@ export default class Core3DViewer extends PureComponent {
     const featuresAndFutures = new Set(
       Object.keys(streams)
         .concat(Object.keys(lookAheads))
-        .filter(
-          streamName => streamFilter(streamName) && (!streamSettings || streamSettings[streamName])
-        )
+        .filter(streamFilter)
     );
 
     return [

--- a/modules/core/src/components/log-viewer/index.js
+++ b/modules/core/src/components/log-viewer/index.js
@@ -156,8 +156,7 @@ class LogViewer extends PureComponent {
 
 const getLogState = log => ({
   frame: log.getCurrentFrame(),
-  metadata: log.getMetadata(),
-  streamSettings: log.getStreamSettings()
+  metadata: log.getMetadata()
 });
 
 export default connectToLog({getLogState, Component: LogViewer});

--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -1,4 +1,4 @@
-import {getXVIZSettings, getXVIZConfig} from '@xviz/parser';
+import {getXVIZSettings} from '@xviz/parser';
 import {clamp} from 'math.gl';
 
 import {getTimeSeries} from '../utils/metrics-helper';
@@ -121,7 +121,24 @@ export default class XVIZLoaderInterface {
 
   getLogSynchronizer = () => this.get('logSynchronizer');
 
-  getStreams = () => this.get('streams');
+  _getStreams = () => this.get('streams');
+
+  getStreams = createSelector(
+    this,
+    [this.getStreamSettings, this._getStreams],
+    (streamSettings, streams) => {
+      if (!streamSettings || !streams) {
+        return streams;
+      }
+      const result = {};
+      for (const streamName in streams) {
+        if (streamSettings[streamName]) {
+          result[streamName] = streams[streamName];
+        }
+      }
+      return result;
+    }
+  );
 
   getBufferRange() {
     throw new Error('not implemented');
@@ -147,18 +164,18 @@ export default class XVIZLoaderInterface {
     this,
     [
       this.getLogSynchronizer,
-      this.getMetadata,
+      this.getStreamSettings,
       this.getCurrentTime,
       this.getLookAhead,
       this.getStreams
     ],
     // `getStreams` is only needed to trigger recomputation.
     // The logSynchronizer has access to the streamBuffer.
-    (logSynchronizer, metadata, timestamp, lookAhead) => {
-      if (logSynchronizer && metadata && Number.isFinite(timestamp)) {
+    (logSynchronizer, streamSettings, timestamp, lookAhead) => {
+      if (logSynchronizer && Number.isFinite(timestamp)) {
         logSynchronizer.setTime(timestamp);
         logSynchronizer.setLookAheadTimeOffset(lookAhead);
-        return logSynchronizer.getCurrentFrame(metadata.streams);
+        return logSynchronizer.getCurrentFrame(streamSettings);
       }
       return null;
     }
@@ -169,43 +186,6 @@ export default class XVIZLoaderInterface {
     getTimeSeries({metadata, streams})
   );
 
-  getTimestamps = createSelector(this, this.getStreams, streams => {
-    const {PRIMARY_POSE_STREAM} = getXVIZConfig();
-    const vehiclePoses = streams && streams[PRIMARY_POSE_STREAM];
-    if (vehiclePoses) {
-      // TODO(twojtasz): normalize 'time' vs 'timestamp' in parsing
-      return vehiclePoses.map(pose => pose.time || pose.timestamp);
-    }
-    return null;
-  });
-
-  getImageFrames = createSelector(
-    this,
-    [this.getMetadata, this.getStreams, this.getTimestamps],
-    (metadata, streams, timestamps) => {
-      if (streams && metadata) {
-        const frames = {};
-        Object.keys(streams).forEach(streamName => {
-          const streamMetadata = metadata.streams[streamName];
-          if (!streamMetadata || streamMetadata.primitive_type !== 'image') {
-            return;
-          }
-          frames[streamName] = streams[streamName].map((frame, i) => {
-            const timestamp = timestamps[i];
-            if (frame && frame.images[0]) {
-              // assign timestamp of vehicle pose to image frame
-              Object.assign(frame.images[0], {timestamp});
-            }
-            return frame && frame.images[0];
-          });
-        });
-        return frames;
-      }
-
-      return null;
-    }
-  );
-
   /* Private actions */
   _update = () => {
     this._updateTimer = null;
@@ -214,7 +194,7 @@ export default class XVIZLoaderInterface {
 
   _setMetadata(metadata) {
     this.set('metadata', metadata);
-    if (metadata.streams && Object.keys(metadata.streams) > 0) {
+    if (metadata.streams && Object.keys(metadata.streams).length > 0) {
       this.set('streamSettings', metadata.streams);
     }
     const timestamp = this.get('timestamp');

--- a/modules/core/src/utils/image-buffer.js
+++ b/modules/core/src/utils/image-buffer.js
@@ -50,8 +50,8 @@ export default class ImageBuffer {
     for (const frame of buffer.keys()) {
       if (
         bufferedFrames.length === 0 ||
-        frame.timestamp < bufferedFrames[0].timestamp ||
-        frame.timestamp > bufferedFrames[bufferedFrames.length - 1].timestamp
+        frame.time < bufferedFrames[0].time ||
+        frame.time > bufferedFrames[bufferedFrames.length - 1].time
       ) {
         this.imageDeleter(buffer.get(frame));
         buffer.delete(frame);
@@ -63,7 +63,7 @@ export default class ImageBuffer {
       if (!buffer.has(frame)) {
         const data = {};
 
-        data.promise = this.imageLoader(frame).then(image => {
+        data.promise = this.imageLoader(frame.images[0]).then(image => {
           data.image = image;
           return image;
         });
@@ -82,7 +82,7 @@ export default class ImageBuffer {
 
     // Find the frame closest to the current timestamp
     allFrames.forEach((frame, i) => {
-      const delta = currentTime - frame.timestamp;
+      const delta = currentTime - frame.time;
       if (delta >= 0 && delta < bestDelta) {
         bestDelta = delta;
         currentFrame = frame;

--- a/test/modules/core/utils/image-buffer.spec.js
+++ b/test/modules/core/utils/image-buffer.spec.js
@@ -21,12 +21,12 @@ function TestImageHandler() {
 
 const testFrames = [
   {
-    timestamp: 1000,
-    imageData: 'not a real image 1'
+    time: 1000,
+    images: [{imageData: 'not a real image 1'}]
   },
   {
-    timestamp: 1100,
-    imageData: 'not a real image 2'
+    time: 1100,
+    images: [{imageData: 'not a real image 2'}]
   }
 ];
 
@@ -46,7 +46,7 @@ test('ImageBuffer#set & get frames', t => {
 
   const frame = imageBuffer.get(currentFrame);
   frame.promise.then(x => {
-    t.equal(frame.image.imageData, testFrames[0].imageData, 'Returns correct data from get()');
+    t.equal(frame.image.imageData, 'not a real image 1', 'Returns correct data from get()');
     t.end();
   });
 });


### PR DESCRIPTION
- Bug: `streamSettings` is never set
- Bug: Turning off a stream in `streamSettings` does not remove it from `getStreams()` and `getCurrentFrame()`
- Perf: Avoid creating new objects in `getImageFrames()`, use original time slice format