### PR TITLE
Default to IDENTITY for stream coordinate system

### DIFF
--- a/modules/core/src/utils/transform.js
+++ b/modules/core/src/utils/transform.js
@@ -20,9 +20,6 @@ export function resolveCoordinateTransform(frame, streamMetadata = {}, getTransf
       coordinateSystem = COORDINATE_SYSTEM.LNGLAT;
       break;
 
-    case COORDINATE.IDENTITY:
-      break;
-
     case COORDINATE.DYNAMIC:
       // cache calculated transform matrix for each frame
       transforms[transform] = transforms[transform] || getTransformMatrix(transform, frame);
@@ -32,8 +29,11 @@ export function resolveCoordinateTransform(frame, streamMetadata = {}, getTransf
       break;
 
     case COORDINATE.VEHICLE_RELATIVE:
-    default:
       modelMatrix = vehicleRelativeTransform;
+      break;
+
+    case COORDINATE.IDENTITY:
+    default:
   }
 
   if (pose) {


### PR DESCRIPTION
Our documentation states that the default should be IDENTITY
https://github.com/uber/xviz/blob/master/docs/protocol-schema/session-protocol.md#stream_metadata

This is currently resolved in Streetscape.gl and was VEHICLE_RELATIVE