### PR TITLE
Fix imports of layers module

### DIFF
--- a/modules/layers/src/index.js
+++ b/modules/layers/src/index.js
@@ -1,3 +1,3 @@
-export {default as SignLayer} from './layers/sign-layer/sign-layer';
-export {default as TrafficLightLayer} from './layers/traffic-light-layer/traffic-light-layer';
-export {default as ImageryLayer} from './layers/imagery-layer/imagery-layer';
+export {default as SignLayer} from './sign-layer/sign-layer';
+export {default as TrafficLightLayer} from './traffic-light-layer/traffic-light-layer';
+export {default as ImageryLayer} from './imagery-layer/imagery-layer';


### PR DESCRIPTION
A quick fix for the imports in the new layers submodule.

Otherwise they were creating fatal build errors when attempting to run the examples.