### PR TITLE
Remove dependency on XVIZ git clone in CI flow

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -x
-
-# Clone xviz
-git clone git@github.com:uber/xviz.git xviz || true
-
-# Update xviz to latest
-cd xviz && git pull origin master && cd ../

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,4 @@ RUN chmod a+x /etc/init.d/xvfb
 
 COPY . /streetscape/
 
-RUN mv /streetscape/xviz /xviz && \
-  cd /xviz && \
-  yarn bootstrap
-
 RUN cd /streetscape/ && yarn bootstrap


### PR DESCRIPTION
We are using public packages now and do not need to clone XVIZ directly.