### PR TITLE
Fix issue with attributeManager not being defined

### DIFF
--- a/modules/layers/src/sign-layer/sign-layer.js
+++ b/modules/layers/src/sign-layer/sign-layer.js
@@ -31,7 +31,7 @@ export default class SignLayer extends IconLayer {
   initializeState() {
     super.initializeState();
 
-    const {attributeManager} = this.state;
+    const attributeManager = this.getAttributeManager();
     attributeManager.addInstanced({
       instanceAngles: {size: 1, accessor: 'getAngle'}
     });


### PR DESCRIPTION
Accessing the attributeManager through `this.state` is deprecated
and is causing an issue with the latest deck.gl.

Change to use the accessor function and the issue went away.