### PR TITLE
Export mergeXVIZStyles

### DIFF
--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -51,6 +51,9 @@ export {default as TurnSignalWidget} from './components/hud/turn-signal-widget';
 // Assets
 export {default as CarMesh} from './cars';
 
+// Utils
+export {mergeXVIZStyles} from './utils/style';
+
 // Constants
 export {COORDINATE, VIEW_MODE} from './constants';
 

--- a/modules/core/src/utils/style.js
+++ b/modules/core/src/utils/style.js
@@ -24,7 +24,7 @@
  *
  * @param style1 {object} Secondary stylesheet
  * @param style2 {object} Primary stylesheet
- * @returns {object} Merged styleheet with Primary rules taking precedence
+ * @returns {object} Merged stylesheet with Primary rules taking precedence
  */
 export function mergeXVIZStyles(style1, style2) {
   if (!style1) {


### PR DESCRIPTION
Exporting `mergeXVIZStyles` so that it can be used in external projects.