### PR TITLE
Simplify XVIZLoaderInterface

### DIFF
--- a/docs/api-reference/xviz-loader-interface.md
+++ b/docs/api-reference/xviz-loader-interface.md
@@ -84,7 +84,7 @@ Returns the current stream settings.
 
 Returns all loaded streams.
 
-##### getBufferRange()
+##### getBufferedTimeRanges()
 
 Returns the loaded time ranges of the buffer, as an array of `[start, end]` timestamps.
 
@@ -96,13 +96,13 @@ Returns the start timestamp of the log.
 
 Returns the end timestamp of the log.
 
-##### getBufferStart()
+##### getBufferStartTime()
 
-Returns the start timestamps of the current buffer.
+Returns the start timestamp of the requested buffer.
 
-##### getBufferEnd()
+##### getBufferEndTime()
 
-Returns the end timestamps of the current buffer.
+Returns the end timestamp of the requested buffer.
 
 ##### getCurrentFrame()
 
@@ -141,24 +141,15 @@ class MyLoader extends XVIZLoaderInterface {
 
     getMetadata(this.options)
       .then(metadata => {
-        this.set('logSynchronizer', new StreamSynchronizer(streamBuffer));
-        this._setMetadata(metadata);
-        this.emit('ready', metadata);
+        this._onXVIZMessage(metadata);
       })
       .then(() =>
         getTimeslices(this.options, timeslice => {
-          streamBuffer.insert(timeslice);
-          this.set('streams', streamBuffer.getStreams());
-          this.emit('update', timeslice);
+          this._onXVIZMessage(timeslice);
         })
       )
       .then(() => this.emit('done'))
       .catch(error => this.emit('error', error));
-  }
-
-  getBufferRange() {
-    const {start, end} = this.streamBuffer.getBufferRange();
-    return [[start, end]];
   }
 
   close() {}
@@ -177,15 +168,17 @@ Called to start loading data.
 
 Called to stop loading data.
 
-##### getBufferRange()
-
-Called to get the loaded time range, an array of `[start, end]` timestamps.
-
 ### Private Members
 
 ##### options
 
 The options object passed into the constructor.
+
+##### streamBuffer
+
+An instance of XVIZ's
+[XVIZStreamBuffer](https://github.com/uber/xviz/blob/master/docs/api-reference/xviz-stream-buffer.md).
+Must be supplied by the subclass.
 
 ### Private Methods
 
@@ -204,6 +197,11 @@ Retrieve a saved value from the current state.
 
 Fire an event with the specified arguments.
 
-##### \_setMetadata(metadata)
+##### onXVIZMessage(message)
 
-Update the log metadata.
+Handler for a parsed XVIZ message, returned by
+[parseStreamMessage](https://github.com/uber/xviz/blob/master/docs/api-reference/parse-xviz.md).
+
+##### onError(message)
+
+Handler for errors.

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -162,8 +162,8 @@ class XVIZMetricComponent extends PureComponent {
 const getLogState = log => ({
   currentTime: log.getCurrentTime(),
   timeSeries: log.getTimeSeries(),
-  startTime: log.getBufferStart(),
-  endTime: log.getBufferEnd()
+  startTime: log.getBufferStartTime(),
+  endTime: log.getBufferEndTime()
 });
 
 export default connectToLog({getLogState, Component: XVIZMetricComponent});

--- a/modules/core/src/components/playback-control/index.js
+++ b/modules/core/src/components/playback-control/index.js
@@ -39,7 +39,7 @@ class PlaybackControl extends PureComponent {
     lookAhead: PropTypes.number,
     startTime: PropTypes.number,
     endTime: PropTypes.number,
-    bufferRange: PropTypes.array,
+    buffered: PropTypes.array,
 
     // state override
     isPlaying: PropTypes.bool,
@@ -131,7 +131,7 @@ class PlaybackControl extends PureComponent {
   _animate = () => {
     if (this.state.isPlaying) {
       const now = Date.now();
-      const {startTime, endTime, bufferRange, timestamp} = this.props;
+      const {startTime, endTime, buffered, timestamp} = this.props;
       const {timeScale} = this.state;
       const lastUpdate = this._lastAnimationUpdate;
       const {PLAYBACK_FRAME_RATE, TIME_WINDOW} = getXVIZConfig();
@@ -146,7 +146,7 @@ class PlaybackControl extends PureComponent {
       }
 
       // check buffer availability
-      if (bufferRange.some(r => newTimestamp >= r[0] && newTimestamp <= r[1] + TIME_WINDOW)) {
+      if (buffered.some(r => newTimestamp >= r[0] && newTimestamp <= r[1] + TIME_WINDOW)) {
         // only move forward if buffer is loaded
         // otherwise pause and wait
         this._onTimeChange(newTimestamp);
@@ -190,13 +190,13 @@ class PlaybackControl extends PureComponent {
   };
 
   render() {
-    const {startTime, endTime, timestamp, lookAhead, bufferRange, ...otherProps} = this.props;
+    const {startTime, endTime, timestamp, lookAhead, buffered, ...otherProps} = this.props;
 
     if (!Number.isFinite(timestamp) || !Number.isFinite(startTime)) {
       return null;
     }
 
-    const buffers = bufferRange.map(r => ({
+    const bufferRange = buffered.map(r => ({
       startTime: Math.max(r[0], startTime),
       endTime: Math.min(r[1], endTime)
     }));
@@ -204,7 +204,7 @@ class PlaybackControl extends PureComponent {
     return (
       <DualPlaybackControl
         {...otherProps}
-        bufferRange={buffers}
+        bufferRange={bufferRange}
         currentTime={timestamp}
         lookAhead={lookAhead}
         startTime={startTime}
@@ -227,7 +227,7 @@ const getLogState = log => ({
   lookAhead: log.getLookAhead(),
   startTime: log.getLogStartTime(),
   endTime: log.getLogEndTime(),
-  bufferRange: log.getBufferRange()
+  buffered: log.getBufferedTimeRanges()
 });
 
 export default connectToLog({getLogState, Component: PlaybackControl});

--- a/modules/core/src/loaders/xviz-file-loader.js
+++ b/modules/core/src/loaders/xviz-file-loader.js
@@ -79,6 +79,7 @@ export default class XVIZFileLoader extends XVIZLoaderInterface {
     }
 
     if (startFrame >= this._numberOfFrames) {
+      this.emit('done');
       return;
     }
 

--- a/modules/core/src/loaders/xviz-live-loader.js
+++ b/modules/core/src/loaders/xviz-live-loader.js
@@ -94,19 +94,6 @@ export default class XVIZLiveLoader extends XVIZWebsocketLoader {
     });
   }
 
-  getBufferRange() {
-    const bufferRange = this.streamBuffer.getBufferRange();
-    return [[bufferRange.start, bufferRange.end]];
-  }
-
-  getBufferStart() {
-    return this.streamBuffer && this.streamBuffer.getBufferRange().start;
-  }
-
-  getBufferEnd() {
-    return this.streamBuffer && this.streamBuffer.getBufferRange().end;
-  }
-
   seek(timestamp) {
     super.seek(timestamp);
 
@@ -114,10 +101,21 @@ export default class XVIZLiveLoader extends XVIZWebsocketLoader {
     this.streamBuffer.setCurrentTime(timestamp);
   }
 
+  /* Hook overrides */
+
   _onOpen = () => {};
 
-  _onXVIZTimeslice = (message, bufferUpdated) => {
+  _getBufferStartTime() {
+    return this.streamBuffer.getBufferRange().start;
+  }
+
+  _getBufferEndTime() {
+    return this.streamBuffer.getBufferRange().end;
+  }
+
+  _onXVIZTimeslice(message) {
+    super._onXVIZTimeslice(message);
     // Live loader always shows latest data
     this.seek(message.timestamp);
-  };
+  }
 }

--- a/test/modules/core/loaders/xviz-live-loader.spec.js
+++ b/test/modules/core/loaders/xviz-live-loader.spec.js
@@ -74,16 +74,16 @@ test('XVIZLiveLoader#connect, seek', t => {
     t.deepEquals(socket.flush(), [], 'No data till metadata');
 
     // Mock metadata
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.METADATA, data: {version: '2.0.0'}});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.METADATA, data: {version: '2.0.0'}});
     t.deepEquals(socket.flush(), [], 'No client request after metadata');
 
     loader.seek(1005);
     t.deepEquals(socket.flush(), [], 'seek: no socket updates');
 
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1008});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1009});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1010});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1008});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1009});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1010});
 
     // t.deepEquals(loader.getBufferRange(), [[1, 2]], 'BufferRange includes all messages');
 
@@ -109,23 +109,23 @@ test('XVIZLiveLoader#metadata missing start_time', t => {
     t.deepEquals(socket.flush(), [], 'No data till metadata');
 
     // Mock metadata with missing start_time
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.METADATA});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.METADATA});
     t.deepEquals(socket.flush(), [], 'No client request after metadata');
 
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
 
     loader.seek(1007);
     t.deepEquals(socket.flush(), [], 'seek: no socket updates');
 
     t.equals(
-      loader.getBufferStart(),
+      loader.getBufferStartTime(),
       987,
-      'getBufferStart() based on first message - 30/3 * 2 preBuffer'
+      'getBufferStartTime() based on first message - 30/3 * 2 preBuffer'
     );
     t.equals(
-      loader.getBufferEnd(),
+      loader.getBufferEndTime(),
       1017,
-      'getBufferEnd() based on first message + 30/3 = 10 postBuffer'
+      'getBufferEndTime() based on first message + 30/3 = 10 postBuffer'
     );
 
     t.equals(loader.getLogStartTime(), undefined, 'getLogStartTime() is undefined in liveMode');

--- a/test/modules/core/loaders/xviz-stream-loader.spec.js
+++ b/test/modules/core/loaders/xviz-stream-loader.spec.js
@@ -214,7 +214,7 @@ test('XVIZStreamLoader#connect, seek', t => {
     t.deepEquals(socket.flush(), [], 'No data till metadata');
 
     // Mock metadata
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.METADATA, start_time: 1000, end_time: 1030});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.METADATA, start_time: 1000, end_time: 1030});
     t.deepEquals(
       socket.flush(),
       [{type: 'xviz/transform_log', data: {start_timestamp: 1000, end_timestamp: 1010, id: '0'}}],
@@ -231,10 +231,10 @@ test('XVIZStreamLoader#connect, seek', t => {
       'seek: update with correct parameters'
     );
 
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1008});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1009});
-    loader._onWSMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1010});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1007});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1008});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1009});
+    loader.onXVIZMessage({type: LOG_STREAM_MESSAGE.TIMESLICE, timestamp: 1010});
 
     loader.seek(1001);
     t.deepEquals(


### PR DESCRIPTION
- Make `streamBuffer` mandatory; automatically construct `StreamSynchronizer` instance
- Added `onXVIZMessage` method for shared logic; hooks for subclassing
- Decouple `getCurrentFrame` from `getStreams` (perf)
- Renamed a few confusing selectors:
  + `getBufferRange` -> `getBufferedTimeRanges`
  + `getBufferStart` -> `getBufferStartTime`
  + `getBufferEnd` -> `getBufferEndTime`
