### PR TITLE
Fix light settings coordinate system

### DIFF
--- a/modules/core/src/components/log-viewer/constants.js
+++ b/modules/core/src/components/log-viewer/constants.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import {CubeGeometry} from 'luma.gl';
+import {COORDINATE_SYSTEM} from 'deck.gl';
 
 export const DEFAULT_CAR = {
   mesh: new CubeGeometry(),
@@ -31,6 +32,8 @@ export const DEFAULT_ORIGIN = [0, 0, 0];
 export const CAR_DATA = [[0, 0, 0]];
 
 export const LIGHT_SETTINGS = {
+  coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+  coordinateOrigin: DEFAULT_ORIGIN,
   lightsPosition: [0, 0, 5000, -1000, 400, 1000],
   ambientRatio: 0.5,
   diffuseRatio: 0.2,

--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -131,6 +131,12 @@ export default class Core3DViewer extends PureComponent {
       });
     }
     if (this.props.frame !== nextProps.frame) {
+      const {frame} = this.props;
+      const lightSettings = {
+        ...LIGHT_SETTINGS,
+        coordinateOrigin: (frame && frame.origin) || DEFAULT_ORIGIN
+      };
+      this.setState({lightSettings});
       stats.bump('frame-update');
     }
   }
@@ -178,6 +184,7 @@ export default class Core3DViewer extends PureComponent {
 
   _getCarLayer() {
     const {frame, car} = this.props;
+    const {lightSettings} = this.state;
     const {
       origin = DEFAULT_ORIGIN,
       mesh,
@@ -202,7 +209,7 @@ export default class Core3DViewer extends PureComponent {
       getSize: Number.isFinite(scale) ? [scale, scale, scale] : scale,
       texture,
       wireframe,
-      lightSettings: LIGHT_SETTINGS
+      lightSettings
     });
   }
 
@@ -220,7 +227,7 @@ export default class Core3DViewer extends PureComponent {
     }
 
     const {streams, lookAheads = {}} = frame;
-    const {styleParser} = this.state;
+    const {styleParser, lightSettings} = this.state;
 
     const streamFilter = normalizeStreamFilter(this.props.streamFilter);
     const featuresAndFutures = new Set(
@@ -253,7 +260,7 @@ export default class Core3DViewer extends PureComponent {
               ...coordinateProps,
 
               pickable: showTooltip || primitives[0].id,
-              lightSettings: LIGHT_SETTINGS,
+              lightSettings,
 
               data: primitives,
               style: stylesheet,
@@ -273,6 +280,8 @@ export default class Core3DViewer extends PureComponent {
               ...coordinateProps,
 
               pickable: showTooltip,
+              lightSettings,
+
               data: stream.pointCloud,
               style: stylesheet,
               vehicleRelativeTransform: frame.vehicleRelativeTransform,


### PR DESCRIPTION
For https://github.com/uber/xviz/issues/402

Default light positions are in METER_OFFSET coordinate system but did not explicitly state so. At runtime, it falls back to the layer's coordinate system, resulting in an exception when GEOGRAPHIC coordinates are used.