### PR TITLE
Add URL passing to the XVIZ Loaders

### DIFF
--- a/dev-docs/viewer-app.md
+++ b/dev-docs/viewer-app.md
@@ -3,9 +3,9 @@
 This application has additional features beyond the
 [get-started](https://github.com/uber/streetscape.gl/tree/master/docs/get-started/starter-kit.md)
 that are detailed here. Instructions and features in the get-started application will work with the
-viewer application. Additional features are documented below.
+viewer application.
 
-The viewer application is intented to work with the _@xviz/server_ module and expose the full
+The viewer application is intented to work with the _@xviz/server_ module and exposes the full
 capabilities of the XVIZ protocol and server.
 
 # Developer Features
@@ -21,7 +21,7 @@ sources rather than hosting a single XVIZ data source.
 For example, if there is a directory `xviz-data` that had the following sub-folders:
 
 ```
-xviz-data/
+~/xviz-data/
   |
   +-- xviz-sample-1/
   |

--- a/dev-docs/viewer-app.md
+++ b/dev-docs/viewer-app.md
@@ -1,0 +1,57 @@
+# Developer Viewer Application
+
+This application has additional features beyond the
+[get-started](https://github.com/uber/streetscape.gl/tree/master/docs/get-started/starter-kit.md)
+that are detailed here. Instructions and features in the get-started application will work with the
+viewer application. Additional features are documented below.
+
+The viewer application is intented to work with the _@xviz/server_ module and expose the full
+capabilities of the XVIZ protocol and server.
+
+# Developer Features
+
+Below is the list of features and application details the viewer application has beyond the
+get-started example.
+
+## URL path support
+
+The _@xviz/server_ supports using the `path` component of the URL to access arbitrary XVIZ data
+sources rather than hosting a single XVIZ data source.
+
+For example, if there is a directory `xviz-data` that had the following sub-folders:
+
+```
+xviz-data/
+  |
+  +-- xviz-sample-1/
+  |
+  +-- xviz-sample-2/
+  |
+  +-- ros-example.bag
+```
+
+And the _@xviz/server_ is started with the following arguments:
+
+```
+xviz/modules/server$ ./bin/xvizserver --d ~/xviz-data
+```
+
+The various XVIZ data sources can be accessed with the following URL's respectively.
+
+ - http://localhost:8080/xviz-sample-1
+ - http://localhost:8080/xviz-sample-2
+ - http://localhost:8080/ros-example
+
+## Query Parameters
+
+| Parameter        | Description                                                                           | Default                 |
+| ---------------- | ------------------------------------------------------------------------------------- | ----------------------- |
+| **server**       | Override XVIZ server URL                                                              | ws://localhost:3000     |
+| **log**          | A field send upon initial connection with the XVIZ server                             | default                 |
+| **worker**       | Boolean to control if workers are enabled, useful to debug XVIZ parsing               | true                    |
+| **profile**      | A field send upon initial connection with the XVIZ Server                             | null                    |
+| **timestamp**    | A field sent upon initial connection interpreted as the starting time to stream       | null                    |
+| **duration**     | Specifies the duration of the XVIZ data to stream                                     | 30 seconds              |
+| **bufferLength** | In **live** log mode, this controls how much of the data is kept in front-end buffers | Default is _30_ seconds |
+
+Example: `http://localhost:8080?server=ws://remote-dev-xviz:3000&log=test-log-name`

--- a/test/apps/viewer/README.md
+++ b/test/apps/viewer/README.md
@@ -1,7 +1,6 @@
 # Developer Viewer App
 
-This app was based on the get-started app but with additional features for developers
-to test all the features in XVIZ and Streetscape.gl
+This is an application to enable testing and validation of all the features of XVIZ and Streetscape.gl
 
 ## Running the Viewer App
 
@@ -10,13 +9,13 @@ cd streetscape.gl/test/apps/viewer
 # install dependencies
 yarn
 # start the app
-yarn start
+yarn start-streaming
 ```
 
 ## Running an XVIZ server
 
 ```bash
-cd streetscape.gl/modules/server
-# start the app
-./bin/babel-xvizserver -p 3000 -d ../directory/of/xviz-data
+cd xviz/modules/server
+# start the server 
+./bin/babel-xvizserver -d ../directory/of/xviz-data
 ```

--- a/test/apps/viewer/README.md
+++ b/test/apps/viewer/README.md
@@ -1,0 +1,22 @@
+# Developer Viewer App
+
+This app was based on the get-started app but with additional features for developers
+to test all the features in XVIZ and Streetscape.gl
+
+## Running the Viewer App
+
+```bash
+cd streetscape.gl/test/apps/viewer
+# install dependencies
+yarn
+# start the app
+yarn start
+```
+
+## Running an XVIZ server
+
+```bash
+cd streetscape.gl/modules/server
+# start the app
+./bin/babel-xvizserver -p 3000 -d ../directory/of/xviz-data
+```

--- a/test/apps/viewer/README.md
+++ b/test/apps/viewer/README.md
@@ -2,6 +2,8 @@
 
 This is an application to enable testing and validation of all the features of XVIZ and Streetscape.gl
 
+Detailed documentation for this application is found in our [dev-docs/viewer-app.md](https://github.com/uber/streetscape.gl/tree/master/dev-docs/viewer-app.md)
+
 ## Running the Viewer App
 
 ```bash

--- a/test/apps/viewer/index.html
+++ b/test/apps/viewer/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>streetscape.gl Viewer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+body { margin: 0; }
+#container { position: fixed; display: flex; width: 100vw; height: 100vh; overflow: hidden; }
+#control-panel { box-sizing: border-box; width: 320px; padding: 12px; position: relative; z-index: 1; box-shadow: 0 0 8px rgba(0,0,0,0.3); height: 100%; overflow-x: hidden; overflow-y: auto; }
+#control-panel hr { margin: 24px -12px; opacity: 0.3; }
+#log-panel { flex-grow: 1; display: flex; flex-direction: column; height: 100%; }
+#map-view { flex-grow: 1; position: relative; }
+#timeline { padding: 24px 0; position: relative; }
+#hud { position: absolute; top: 12px; right: 12px; display: flex; flex-direction: column; box-shadow: 0 0 8px rgba(0,0,0,0.3); }
+#hud hr {margin: 0; opacity: 0.3;}
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src='bundle.js'></script>
+  </body>
+</html>

--- a/test/apps/viewer/package.json
+++ b/test/apps/viewer/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "streetscape.gl-viewer",
+  "description": "A developer viewing app for streetscape.gl",
+  "version": "0.1.0",
+  "scripts": {
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-streaming-local": "webpack-dev-server --env.local --env.stream --progress --hot --open",
+    "start-live-local": "webpack-dev-server --env.local --env.live --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-streaming": "webpack-dev-server --env.stream --progress --hot --open",
+    "start-live": "webpack-dev-server --env.live --progress --hot --open"
+  },
+  "dependencies": {
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "streetscape.gl": "^1.0.0-beta"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.0",
+    "source-map-loader": "^0.2.3",
+    "webpack": "^4.20.0",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/test/apps/viewer/src/app.js
+++ b/test/apps/viewer/src/app.js
@@ -1,0 +1,174 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* global document, console, window */
+/* eslint-disable no-console, no-unused-vars, no-undef */
+import React, {PureComponent} from 'react';
+import {render} from 'react-dom';
+
+import {setXVIZConfig} from '@xviz/parser';
+import {
+  LogViewer,
+  PlaybackControl,
+  StreamSettingsPanel,
+  MeterWidget,
+  TrafficLightWidget,
+  TurnSignalWidget,
+  XVIZPanel,
+  VIEW_MODE
+} from 'streetscape.gl';
+import {Form} from '@streetscape.gl/monochrome';
+
+import {XVIZ_CONFIG, APP_SETTINGS, MAPBOX_TOKEN, MAP_STYLE, XVIZ_STYLE, CAR} from './constants';
+import {default as XVIZLoaderFactory} from './log-from-factory';
+
+setXVIZConfig(XVIZ_CONFIG);
+
+// Pass through path & parameters to loaders
+function buildLoaderOptions() {
+  const url = new URL(window.location);
+  const params = url.searchParams;
+
+  const server = params.get('server') || 'ws://localhost:3000';
+
+  const options = {
+    logGuid: params.get('log') || 'mock',
+    serverConfig: {
+      defaultLogLength: 30,
+      serverUrl: `${server}${url.pathname}`
+    },
+    worker: Boolean(params.get('worker')) || true,
+    maxConcurrency: 4
+  };
+
+  const addParam = (param, prop, dflt) => {
+    if (params.has(param) || dflt) {
+      options[prop] = params.get(param) || dflt;
+    }
+  };
+
+  addParam('profile', 'logProfile');
+  addParam('timestamp', 'timestamp');
+  addParam('duration', 'duration');
+
+  if (__IS_LIVE__) {
+    addParam('bufferLength', 'bufferLength', 10);
+  }
+
+  return options;
+}
+
+// __IS_STREAMING__ and __IS_LIVE__ are defined in webpack.config.js
+const exampleLog = XVIZLoaderFactory.load(__IS_STREAMING__, __IS_LIVE__, buildLoaderOptions());
+
+class Example extends PureComponent {
+  state = {
+    log: exampleLog,
+    settings: {
+      viewMode: 'PERSPECTIVE',
+      showTooltip: false
+    },
+    panels: []
+  };
+
+  componentDidMount() {
+    const {log} = this.state;
+    log
+      .on('ready', () => {
+        const metadata = log.getMetadata();
+        this.setState({
+          panels: Object.keys((metadata && metadata.ui_config) || {})
+        });
+      })
+      .on('error', console.error)
+      .connect();
+  }
+
+  _onSettingsChange = changedSettings => {
+    this.setState({
+      settings: {...this.state.settings, ...changedSettings}
+    });
+  };
+
+  render() {
+    const {log, settings, panels} = this.state;
+
+    return (
+      <div id="container">
+        <div id="control-panel">
+          {panels.map(panelName => [
+            <XVIZPanel key={panelName} log={log} name={panelName} />,
+            <hr key={`${panelName}-divider`} />
+          ])}
+          <Form
+            data={APP_SETTINGS}
+            values={this.state.settings}
+            onChange={this._onSettingsChange}
+          />
+          <StreamSettingsPanel log={log} />
+        </div>
+        <div id="log-panel">
+          <div id="map-view">
+            <LogViewer
+              log={log}
+              mapboxApiAccessToken={MAPBOX_TOKEN}
+              mapStyle={MAP_STYLE}
+              car={CAR}
+              xvizStyles={XVIZ_STYLE}
+              showTooltip={settings.showTooltip}
+              viewMode={VIEW_MODE[settings.viewMode]}
+            />
+            <div id="hud">
+              <TurnSignalWidget log={log} streamName="/vehicle/turn_signal" />
+              <hr />
+              <TrafficLightWidget log={log} streamName="/vehicle/traffic_light" />
+              <hr />
+              <MeterWidget
+                log={log}
+                streamName="/vehicle/acceleration"
+                label="Acceleration"
+                min={-4}
+                max={4}
+              />
+              <hr />
+              <MeterWidget
+                log={log}
+                streamName="/vehicle/velocity"
+                label="Speed"
+                getWarning={x => (x > 6 ? 'FAST' : '')}
+                min={0}
+                max={20}
+              />
+            </div>
+          </div>
+          <div id="timeline">
+            <PlaybackControl
+              width="100%"
+              log={log}
+              formatTimestamp={x => new Date(x).toUTCString()}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+render(<Example />, document.getElementById('app'));

--- a/test/apps/viewer/src/constants.js
+++ b/test/apps/viewer/src/constants.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import {CarMesh} from 'streetscape.gl';
+
+/* eslint-disable camelcase */
+export const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
+
+export const MAP_STYLE = 'mapbox://styles/mapbox/light-v9';
+
+export const XVIZ_CONFIG = {
+  PLAYBACK_FRAME_RATE: 10
+};
+
+export const CAR = CarMesh.sedan({
+  origin: [1.08, -0.32, 0],
+  length: 4.3,
+  width: 2.2,
+  height: 1.5,
+  color: [160, 160, 160]
+});
+
+export const APP_SETTINGS = {
+  viewMode: {
+    type: 'select',
+    title: 'View Mode',
+    data: {TOP_DOWN: 'Top Down', PERSPECTIVE: 'Perspective', DRIVER: 'Driver'}
+  },
+  showTooltip: {
+    type: 'toggle',
+    title: 'Show Tooltip'
+  }
+};
+
+export const XVIZ_STYLE = {
+  '/tracklets/objects': [{name: 'selected', style: {fill_color: '#ff8000aa'}}],
+  '/lidar/points': [{style: {point_color_mode: 'elevation'}}]
+};

--- a/test/apps/viewer/src/log-from-factory.js
+++ b/test/apps/viewer/src/log-from-factory.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {XVIZFileLoader, XVIZLiveLoader, XVIZStreamLoader} from 'streetscape.gl';
+
+class XVIZLoaderFactory {
+  load(stream, live, options) {
+    if (stream) {
+      return this.loadStream(options);
+    } else if (live) {
+      return this.loadLive(options);
+    }
+
+    return this.loadFile();
+  }
+
+  loadFile() {
+    return new XVIZFileLoader({
+      timingsFilePath:
+        'https://raw.githubusercontent.com/uber/xviz-data/master/kitti/2011_09_26_drive_0005_sync/0-frame.json',
+      getFilePath: index =>
+        `https://raw.githubusercontent.com/uber/xviz-data/master/kitti/2011_09_26_drive_0005_sync/${index +
+          1}-frame.glb`,
+      worker: true,
+      maxConcurrency: 4
+    });
+  }
+
+  loadStream(options) {
+    return new XVIZStreamLoader(options);
+  }
+
+  loadLive(options) {
+    return new XVIZLiveLoader(options);
+  }
+}
+
+export default new XVIZLoaderFactory();

--- a/test/apps/viewer/webpack.config.js
+++ b/test/apps/viewer/webpack.config.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint-disable no-process-env */
+const {resolve} = require('path');
+const webpack = require('webpack');
+
+const BABEL_CONFIG = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+  plugins: ['@babel/proposal-class-properties']
+};
+
+const CONFIG = {
+  mode: 'development',
+  devServer: {
+    historyApiFallback: true
+  },
+  entry: {
+    app: resolve('./src/app.js')
+  },
+  devtool: 'source-map',
+  output: {
+    path: resolve('./dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    noParse: /(mapbox-gl)\.js$/,
+    rules: [
+      {
+        // Compile ES2015 using bable
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: BABEL_CONFIG
+          }
+        ]
+      },
+      {
+        // Unfortunately, webpack doesn't import library sourcemaps on its own...
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.EnvironmentPlugin(['MapboxAccessToken'])
+  ]
+};
+
+module.exports = (env = {}) => {
+  let config = Object.assign({}, CONFIG);
+
+  // This switch between streaming and static file loading
+  config.plugins = config.plugins.concat([
+    new webpack.DefinePlugin({__IS_STREAMING__: JSON.stringify(Boolean(env.stream))}),
+    new webpack.DefinePlugin({__IS_LIVE__: JSON.stringify(Boolean(env.live))})
+  ]);
+
+  if (env.local) {
+    // This line enables bundling against src in this repo rather than installed module
+    config = require('../webpack.config.local')(config)(env);
+  }
+
+  return config;
+};


### PR DESCRIPTION
Rather than construct with fix parameters, allow the getting-started
to use the URL determine which data is loaded.

Default behavior w/o a URL path is the same, but if a path is provided
the stream and live loaders will construct their request using the url
path and params

Supports loading multiple logs easily and is useful for testing.

- Pass the URL path as part of the **serverUrl** in the server config
- Support the following query parameters mapped to XVIZLoader options
  - log
  - server
  - profile
  - timestamp
  - duration
  - worker