### PR TITLE
Update docker tests to newer version of Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Docker Image for BuildKite CI
 # -----------------------------
-FROM node:8.12.0
+FROM node:10.15.3
 
 WORKDIR /streetscape
 


### PR DESCRIPTION
This will be based on a supported version of debian and fix the Buildkite errors.