### PR TITLE
New debug panel with XVIZ Parser and Log Viewer stats

### DIFF
--- a/modules/core/src/debug/constants.js
+++ b/modules/core/src/debug/constants.js
@@ -1,0 +1,144 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+export const XVIZ_WORKERS_MONITOR_INTERVAL = 1000; // report interval in  ms.
+
+export const HISTORY_SIZE = 16;
+
+export const DEFAULT_STATS_TITLE = 'Streetscape Performance Metrics';
+
+export const COLOR_PALETTE = {
+  WHITE: '#FFFFFF',
+  BLACK: '#141414',
+  DARK_GREY: '#333333',
+  LIGHT_GREY: '#B3B3B3',
+  BLUE: '#5B91F4',
+  LIGHT_BLUE: '#98baf9',
+  GREEN: '#34a853',
+  ORANGE: '#fbbc05',
+  PURPLE: '#673ab7',
+  RED: '#ea4335'
+};
+
+export const STATS_KEYS = {
+  FPS: 'fps',
+  REDRAW: 'redraw',
+  FRAME_UPDATE: 'frame-update',
+  LOADER_UPDATE: 'loader-update',
+  LOADER_ERROR: 'loader-error'
+};
+
+export const STATS_NAMES = {
+  [STATS_KEYS.FPS]: 'FPS',
+  [STATS_KEYS.REDRAW]: 'Redraw',
+  [STATS_KEYS.FRAME_UPDATE]: 'XVIZ Frames Rendered',
+  [STATS_KEYS.LOADER_UPDATE]: 'XVIZ Frames Loaded',
+  [STATS_KEYS.LOADER_ERROR]: 'XVIZ Loading Errors'
+};
+
+export const STATS_COLORS = {
+  [STATS_KEYS.FPS]: COLOR_PALETTE.BLUE,
+  [STATS_KEYS.REDRAW]: COLOR_PALETTE.GREEN,
+  [STATS_KEYS.FRAME_UPDATE]: COLOR_PALETTE.ORANGE,
+  [STATS_KEYS.LOADER_UPDATE]: COLOR_PALETTE.PURPLE,
+  [STATS_KEYS.LOADER_ERROR]: COLOR_PALETTE.RED
+};
+
+export const STATS_HELP = {
+  [STATS_KEYS.FPS]: 'Number of frames per seconds.',
+  [STATS_KEYS.REDRAW]: 'Number of times WebGLContext was re-rendered.',
+  [STATS_KEYS.FRAME_UPDATE]: 'Number of XVIZ frames rendered to screen.',
+  [STATS_KEYS.LOADER_UPDATE]: 'Number of new XVIZ messages loaded.',
+  [STATS_KEYS.LOADER_ERROR]: 'Number of XVIZ errors generated during loading.'
+};
+
+export const INITIAL_STATS = {counter: 0};
+for (const statName of Object.values(STATS_KEYS)) {
+  INITIAL_STATS[statName] = [{x: INITIAL_STATS.counter, y: 0}];
+}
+
+export const TOOLTIP_STYLE = {
+  arrowSize: 0,
+  borderWidth: 0,
+  background: COLOR_PALETTE.BLACK,
+  body: {
+    maxWidth: null,
+    color: COLOR_PALETTE.WHITE,
+    whiteSpace: 'pre-wrap',
+    fontSize: 14,
+    borderRadius: 5
+  }
+};
+
+export const STYLES = {
+  LOG_VIEWER: {
+    STATS: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      background: COLOR_PALETTE.WHITE
+    },
+    STATS_HELP: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start'
+    },
+    METRIC_CARD: {
+      tooltip: TOOLTIP_STYLE
+    }
+  },
+  WORKERS: {
+    CONTENT: {
+      width: '100%',
+      color: 'black',
+      fontFamily: '"Helvetica Neue",arial,sans-serif',
+      fontSize: 12
+    },
+    SECTION: {
+      margin: '10px 0'
+    },
+    TITLE: {
+      fontSize: 14,
+      fontWeight: 500,
+      padding: '10px 10px 10px 0',
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center'
+    },
+    NAME: {
+      marginRight: 10
+    }
+  },
+  TAG: {
+    borderRadius: 20,
+    padding: '2px 10px',
+    border: 'solid 1.5px',
+    fontSize: 10
+  },
+  POSITIVE: {
+    background: 'rgb(52, 168, 83, 0.1)',
+    color: COLOR_PALETTE.GREEN,
+    borderColor: COLOR_PALETTE.GREEN
+  },
+  NEGATIVE: {
+    background: 'rgb(234, 67, 53, 0.1)',
+    color: COLOR_PALETTE.RED,
+    borderColor: COLOR_PALETTE.RED
+  }
+};

--- a/modules/core/src/debug/log-viewer-stats.js
+++ b/modules/core/src/debug/log-viewer-stats.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React from 'react';
+import {MetricCard, MetricChart} from '@streetscape.gl/monochrome';
+
+import {
+  HISTORY_SIZE,
+  STATS_NAMES,
+  STYLES,
+  STATS_KEYS,
+  STATS_COLORS,
+  DEFAULT_STATS_TITLE,
+  STATS_HELP,
+  INITIAL_STATS
+} from './constants';
+
+const Help = () => {
+  const help = [];
+  for (const [statName, statHelp] of Object.entries(STATS_HELP)) {
+    help.push(
+      <div key={statName} style={{marginBottom: 10}}>
+        <strong>{STATS_NAMES[statName]}</strong>
+        <div>{statHelp}</div>
+      </div>
+    );
+  }
+  return <div style={STYLES.LOG_VIEWER.STATS_HELP}>{help}</div>;
+};
+
+/**
+ * Stat snapshot at a specific point in time.
+ * @typedef {Object} StatsSnapshot
+ * @property {Number} STATS_KEYS.FPS
+ * @property {Number} STATS_KEYS.REDRAW
+ * @property {Number} STATS_KEYS.FRAME_UPDATE
+ * @property {Number} STATS_KEYS.LOADER_UPDATE
+ * @property {Number} STATS_KEYS.LOADER_ERROR
+ */
+
+/**
+ * @typedef {Object} StatValue
+ * @property {Number} x - X-axis value (e.g. time) for this stat.
+ * @property {Number} y - Y-axis value (e.g. value) for this stat.
+ */
+
+/**
+ * @typedef {Object} Stats - History {StatsSnapshot} over time.
+ * @property {Array<StatValue>} STATS_KEYS.FPS
+ * @property {Array<StatValue>} STATS_KEYS.REDRAW
+ * @property {Array<StatValue>} STATS_KEYS.FRAME_UPDATE
+ * @property {Array<StatValue>} STATS_KEYS.LOADER_UPDATE
+ * @property {Array<StatValue>} STATS_KEYS.LOADER_ERROR
+ * @property {Number} counter
+ */
+
+/**
+ * Update stats history with a stats snapshot.
+ * @param {Stats} stats - Stats history.
+ * @param {StatsSnapshot} statsSnapshot - Snapshot used to update stats history.
+ */
+const _updateStats = (stats, statsSnapshot) => {
+  stats.counter += 1;
+
+  for (const statName of Object.values(STATS_KEYS)) {
+    // Drop oldest stat value when we've reached the history size.
+    if (stats[statName].length >= HISTORY_SIZE) {
+      stats[statName] = stats[statName].slice(1);
+    }
+    // Construct new stat value from stats snapshot.
+    const newStatValue = {
+      x: stats.counter,
+      y: (statsSnapshot && statsSnapshot[statName]) || 0
+    };
+    stats[statName].push(newStatValue);
+  }
+  return stats;
+};
+
+/**
+ * Component to render the Log Viewer stats. It consumes a stats snapshot.
+ * Every time the stats snapshot updates, the stats history is updated and
+ * the component renders the updated stats history.
+ * @param {Object} props
+ * @param {StatsSnapshot} props.statsSnapshot
+ */
+export class LogViewerStats extends React.Component {
+  state = {stats: INITIAL_STATS};
+
+  componentWillUpdate(nextProps) {
+    if (nextProps.statsSnapshot !== this.props.statsSnapshot) {
+      const stats = _updateStats(this.state.stats, nextProps.statsSnapshot);
+      this.setState({stats});
+    }
+  }
+
+  render() {
+    const {counter, ...data} = this.state.stats;
+    const title = this.props.title || DEFAULT_STATS_TITLE;
+    return (
+      <div id="stats" style={STYLES.LOG_VIEWER.STATS}>
+        <MetricCard title={title} description={<Help />} style={STYLES.LOG_VIEWER.METRIC_CARD}>
+          <MetricChart
+            width={350}
+            height={200}
+            data={data}
+            highlightX={counter}
+            getColor={statKey => STATS_COLORS[statKey]}
+            formatTitle={statKey => STATS_NAMES[statKey]}
+          />
+        </MetricCard>
+      </div>
+    );
+  }
+}

--- a/modules/core/src/debug/xviz-workers-monitor.js
+++ b/modules/core/src/debug/xviz-workers-monitor.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+/* global setInterval */
+/* global clearInterval */
+
+/**
+ * Keep track of the status of the XVIZ parser worker farm.
+ * Decouple workers status update frequency from status report frequency.
+ */
+import {XVIZ_WORKERS_MONITOR_INTERVAL} from './constants';
+
+export class XvizWorkersMonitor {
+  /**
+   * constructor
+   * @param options {Object} - Monitor options.
+   * @param options.numWorkers {number} - The number of workers.
+   * @param options.reportCallback {function} - Callback called on each monitor report.
+   */
+  constructor(options) {
+    const {numWorkers, reportCallback} = options;
+    this.numWorkers = numWorkers;
+    this.reportCallback = reportCallback;
+    this.interval = null;
+    this.reset();
+  }
+
+  /**
+   * Update worker farm status.
+   *
+   * @param payload {Object} - Payload of @xviz/parser "parseStreamMessage" debug
+   * callback. See https://github.com/uber/xviz/blob/master/docs/api-reference/parse-xviz.md
+   */
+  update = payload => {
+    const {worker, backlog, dropped} = payload;
+    this.status.backlog = backlog;
+    this.status.dropped = dropped;
+    const now = new Date(Date.now());
+    for (const workerId of Object.keys(this.status.workers)) {
+      if (worker === workerId) {
+        this.status.workers[workerId] = {lastUpdated: now, isActive: true};
+      }
+    }
+  };
+
+  /**
+   * If a worker hasn't been active for more than a couple of update intervals,
+   * let's clean up its status and considered it inactive.
+   */
+  cleanup = () => {
+    const now = new Date(Date.now());
+    for (const [workerId, workerStatus] of Object.entries(this.status.workers)) {
+      if (workerStatus.isActive && workerStatus.lastUpdated) {
+        const timeDelta = now.getTime() - workerStatus.lastUpdated.getTime();
+        if (timeDelta > +2 * XVIZ_WORKERS_MONITOR_INTERVAL) {
+          this.status.workers[workerId] = {lastUpdated: now, isActive: false};
+        }
+      }
+    }
+  };
+
+  /**
+   * Reset workers status.
+   */
+  reset = () => {
+    const workers = {};
+    for (let i = 0; i < this.numWorkers; i++) {
+      const workerId = `${i}/${this.numWorkers}`;
+      workers[workerId] = {lastUpdated: null, isActive: false};
+    }
+    this.status = {backlog: 'NA', dropped: 'NA', workers};
+  };
+
+  /**
+   * Start reporting worker farm status.
+   */
+  start = () => {
+    this.stop();
+    this.interval = setInterval(() => {
+      this.cleanup();
+      this.reportCallback(this.status);
+    }, XVIZ_WORKERS_MONITOR_INTERVAL);
+  };
+
+  /**
+   * Stop reporting worker status.
+   */
+  stop = () => {
+    this.reset();
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  };
+}

--- a/modules/core/src/debug/xviz-workers-monitor.js
+++ b/modules/core/src/debug/xviz-workers-monitor.js
@@ -26,7 +26,7 @@
  */
 import {XVIZ_WORKERS_MONITOR_INTERVAL} from './constants';
 
-export class XvizWorkersMonitor {
+export class XVIZWorkersMonitor {
   /**
    * constructor
    * @param options {Object} - Monitor options.

--- a/modules/core/src/debug/xviz-workers-status.js
+++ b/modules/core/src/debug/xviz-workers-status.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React from 'react';
+import {STYLES} from './constants';
+import {XvizWorkersMonitor} from './xviz-workers-monitor';
+
+const ActivityTag = ({isActive}) =>
+  isActive ? (
+    <div style={{...STYLES.TAG, ...STYLES.POSITIVE}}>ACTIVE</div>
+  ) : (
+    <div style={{...STYLES.TAG, ...STYLES.NEGATIVE}}>INACTIVE</div>
+  );
+
+const _formatLastUpdated = lastUpdated =>
+  `${lastUpdated.toLocaleDateString()} ${lastUpdated.toLocaleTimeString()}`;
+
+const Workers = ({workers}) =>
+  Object.entries(workers).map(([workerId, {lastUpdated, isActive}]) => (
+    <div style={STYLES.WORKERS.SECTION} key={workerId}>
+      <div style={STYLES.WORKERS.TITLE}>
+        <div style={STYLES.WORKERS.NAME}>Worker {workerId}</div>
+        <ActivityTag isActive={isActive} />
+      </div>
+      <div style={STYLES.WORKERS.ENTRY}>
+        {lastUpdated
+          ? `Last active at ${_formatLastUpdated(lastUpdated)}`
+          : 'This worker has never been active.'}
+      </div>
+    </div>
+  ));
+
+const Backlog = ({backlog, dropped}) => (
+  <div style={STYLES.WORKERS.SECTION}>
+    <div style={STYLES.WORKERS.TITLE}>XVIZ Worker Farm</div>
+    <div style={STYLES.WORKERS.ENTRY}>{`Queue backlog: ${backlog}`}</div>
+    <div style={STYLES.WORKERS.ENTRY}>{`Dropped: ${dropped}`}</div>
+  </div>
+);
+
+export class XvizWorkersStatus extends React.Component {
+  state = {backlog: 'NA', dropped: 'NA', workers: {}};
+
+  componentWillMount() {
+    const {log} = this.props;
+    this.xvizWorkerMonitor = new XvizWorkersMonitor({
+      numWorkers: log.options.maxConcurrency,
+      reportCallback: ({backlog, dropped, workers}) => {
+        this.setState({backlog, dropped, workers});
+      }
+    });
+    log.options.debug = this.xvizWorkerMonitor.update;
+    this.xvizWorkerMonitor.start();
+  }
+
+  componentWillUnmount() {
+    if (this.xvizWorkerMonitor) {
+      this.xvizWorkerMonitor.stop();
+    }
+  }
+
+  render() {
+    const {backlog, dropped, workers} = this.state;
+    return (
+      <div style={STYLES.WORKERS.CONTENT}>
+        <Backlog backlog={backlog} dropped={dropped} />
+        <Workers workers={workers} />
+      </div>
+    );
+  }
+}

--- a/modules/core/src/debug/xviz-workers-status.js
+++ b/modules/core/src/debug/xviz-workers-status.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 import React from 'react';
 import {STYLES} from './constants';
-import {XvizWorkersMonitor} from './xviz-workers-monitor';
+import {XVIZWorkersMonitor} from './xviz-workers-monitor';
 
 const ActivityTag = ({isActive}) =>
   isActive ? (
@@ -54,12 +54,12 @@ const Backlog = ({backlog, dropped}) => (
   </div>
 );
 
-export class XvizWorkersStatus extends React.Component {
+export class XVIZWorkersStatus extends React.Component {
   state = {backlog: 'NA', dropped: 'NA', workers: {}};
 
   componentWillMount() {
     const {log} = this.props;
-    this.xvizWorkerMonitor = new XvizWorkersMonitor({
+    this.xvizWorkerMonitor = new XVIZWorkersMonitor({
       numWorkers: log.options.maxConcurrency,
       reportCallback: ({backlog, dropped, workers}) => {
         this.setState({backlog, dropped, workers});

--- a/modules/core/src/debug/xviz-workers-status.js
+++ b/modules/core/src/debug/xviz-workers-status.js
@@ -65,7 +65,11 @@ export class XVIZWorkersStatus extends React.Component {
         this.setState({backlog, dropped, workers});
       }
     });
-    log.options.debug = this.xvizWorkerMonitor.update;
+    log._debug = (event, payload) => {
+      if (event === 'parse_message') {
+        this.xvizWorkerMonitor.update(payload);
+      }
+    };
     this.xvizWorkerMonitor.start();
   }
 

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -60,6 +60,6 @@ export {default as XVIZLiveLoader} from './loaders/xviz-live-loader';
 export {default as XVIZFileLoader} from './loaders/xviz-file-loader';
 
 // Debug
-export {XvizWorkersStatus} from './debug/xviz-workers-status';
+export {XVIZWorkersStatus} from './debug/xviz-workers-status';
 export {LogViewerStats} from './debug/log-viewer-stats';
-export {XvizWorkersMonitor} from './debug/xviz-workers-monitor';
+export {XVIZWorkersMonitor} from './debug/xviz-workers-monitor';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -58,3 +58,8 @@ export {default as _XVIZLoaderInterface} from './loaders/xviz-loader-interface';
 export {default as XVIZStreamLoader} from './loaders/xviz-stream-loader';
 export {default as XVIZLiveLoader} from './loaders/xviz-live-loader';
 export {default as XVIZFileLoader} from './loaders/xviz-file-loader';
+
+// Debug
+export {XvizWorkersStatus} from './debug/xviz-workers-status';
+export {LogViewerStats} from './debug/log-viewer-stats';
+export {XvizWorkersMonitor} from './debug/xviz-workers-monitor';

--- a/modules/core/src/loaders/xviz-file-loader.js
+++ b/modules/core/src/loaders/xviz-file-loader.js
@@ -128,7 +128,7 @@ export default class XVIZFileLoader extends XVIZLoaderInterface {
           onError: this.onError,
           worker: options.worker,
           maxConcurrency: options.maxConcurrency,
-          debug: options.debug
+          debug: this._debug.bind(this, 'parse_message')
         });
       }
     });

--- a/modules/core/src/loaders/xviz-file-loader.js
+++ b/modules/core/src/loaders/xviz-file-loader.js
@@ -24,7 +24,7 @@ import {parseStreamMessage, XVIZStreamBuffer} from '@xviz/parser';
 
 import XVIZLoaderInterface from './xviz-loader-interface';
 
-const DEFUALT_BATCH_SIZE = 4;
+const DEFAULT_BATCH_SIZE = 4;
 
 export default class XVIZFileLoader extends XVIZLoaderInterface {
   constructor(options) {
@@ -34,7 +34,7 @@ export default class XVIZFileLoader extends XVIZLoaderInterface {
 
     this._timingsFilePath = options.timingsFilePath;
     this._getFilePath = options.getFilePath;
-    this._batchSize = options.maxConcurrency || DEFUALT_BATCH_SIZE;
+    this._batchSize = options.maxConcurrency || DEFAULT_BATCH_SIZE;
 
     this.streamBuffer = new XVIZStreamBuffer();
     this._isOpen = false;
@@ -127,7 +127,8 @@ export default class XVIZFileLoader extends XVIZLoaderInterface {
           onResult: this.onXVIZMessage,
           onError: this.onError,
           worker: options.worker,
-          maxConcurrency: options.maxConcurrency
+          maxConcurrency: options.maxConcurrency,
+          debug: options.debug
         });
       }
     });

--- a/modules/core/src/loaders/xviz-websocket-loader.js
+++ b/modules/core/src/loaders/xviz-websocket-loader.js
@@ -103,7 +103,12 @@ export default class XVIZWebsocketLoader extends XVIZLoaderInterface {
               message: message.data,
               onResult: this.onXVIZMessage,
               onError: this.onError,
-              debug: this.options.debug || this._debug.bind('parse_message'),
+              debug: payload => {
+                this._debug.bind('parse_message');
+                if (typeof this.options.debug === 'function') {
+                  this.options.debug(payload);
+                }
+              },
               worker: hasMetadata && this.options.worker,
               maxConcurrency: this.options.maxConcurrency
             });

--- a/modules/core/src/loaders/xviz-websocket-loader.js
+++ b/modules/core/src/loaders/xviz-websocket-loader.js
@@ -45,6 +45,7 @@ export default class XVIZWebsocketLoader extends XVIZLoaderInterface {
    *   - serverConfig.retryAttempts {number, optional} - default 3
    * @params worker {string|function, optional}
    * @params maxConcurrency {number, optional} - default 3
+   * @params debug {function} - Debug callback for the XVIZ parser.
    * @params logGuid {string}
    * @params logProfile {string, optional}
    * @params duration {number, optional}
@@ -102,7 +103,7 @@ export default class XVIZWebsocketLoader extends XVIZLoaderInterface {
               message: message.data,
               onResult: this.onXVIZMessage,
               onError: this.onError,
-              debug: this._debug.bind('parse_message'),
+              debug: this.options.debug || this._debug.bind('parse_message'),
               worker: hasMetadata && this.options.worker,
               maxConcurrency: this.options.maxConcurrency
             });

--- a/modules/core/src/loaders/xviz-websocket-loader.js
+++ b/modules/core/src/loaders/xviz-websocket-loader.js
@@ -103,12 +103,7 @@ export default class XVIZWebsocketLoader extends XVIZLoaderInterface {
               message: message.data,
               onResult: this.onXVIZMessage,
               onError: this.onError,
-              debug: payload => {
-                this._debug.bind('parse_message');
-                if (typeof this.options.debug === 'function') {
-                  this.options.debug(payload);
-                }
-              },
+              debug: this._debug.bind(this, 'parse_message'),
               worker: hasMetadata && this.options.worker,
               maxConcurrency: this.options.maxConcurrency
             });

--- a/test/apps/viewer/src/app.js
+++ b/test/apps/viewer/src/app.js
@@ -84,7 +84,8 @@ class Example extends PureComponent {
     log: exampleLog,
     settings: {
       viewMode: 'PERSPECTIVE',
-      showTooltip: false
+      showTooltip: false,
+      showDebug: true
     },
     panels: [],
     statsSnapshot: {}
@@ -109,8 +110,18 @@ class Example extends PureComponent {
     });
   };
 
+  _renderDebugStats = () =>
+    this.state.settings.showDebug ? (
+      <div>
+        <hr />
+        <XVIZWorkersStatus log={this.state.log} />
+        <hr />
+        <LogViewerStats statsSnapshot={this.state.statsSnapshot} />
+      </div>
+    ) : null;
+
   render() {
-    const {log, settings, panels, statsSnapshot} = this.state;
+    const {log, settings, panels} = this.state;
 
     return (
       <div id="container">
@@ -125,10 +136,7 @@ class Example extends PureComponent {
             onChange={this._onSettingsChange}
           />
           <StreamSettingsPanel log={log} />
-          <hr />
-          <XVIZWorkersStatus log={log} />
-          <hr />
-          <LogViewerStats statsSnapshot={statsSnapshot} />
+          {this._renderDebugStats()}
         </div>
         <div id="log-panel">
           <div id="map-view">

--- a/test/apps/viewer/src/app.js
+++ b/test/apps/viewer/src/app.js
@@ -34,6 +34,7 @@ import {
   XVIZPanel,
   VIEW_MODE
 } from 'streetscape.gl';
+import {XvizWorkersStatus, LogViewerStats} from '@streetscape.gl';
 import {Form} from '@streetscape.gl/monochrome';
 
 import {XVIZ_CONFIG, APP_SETTINGS, MAPBOX_TOKEN, MAP_STYLE, XVIZ_STYLE, CAR} from './constants';
@@ -85,7 +86,8 @@ class Example extends PureComponent {
       viewMode: 'PERSPECTIVE',
       showTooltip: false
     },
-    panels: []
+    panels: [],
+    statsSnapshot: {}
   };
 
   componentDidMount() {
@@ -108,11 +110,11 @@ class Example extends PureComponent {
   };
 
   render() {
-    const {log, settings, panels} = this.state;
+    const {log, settings, panels, statsSnapshot} = this.state;
 
     return (
       <div id="container">
-        <div id="control-panel">
+        <div id="control-panel" style={{minWidth: 400}}>
           {panels.map(panelName => [
             <XVIZPanel key={panelName} log={log} name={panelName} />,
             <hr key={`${panelName}-divider`} />
@@ -123,6 +125,10 @@ class Example extends PureComponent {
             onChange={this._onSettingsChange}
           />
           <StreamSettingsPanel log={log} />
+          <hr />
+          <XvizWorkersStatus log={log} />
+          <hr />
+          <LogViewerStats statsSnapshot={statsSnapshot} />
         </div>
         <div id="log-panel">
           <div id="map-view">
@@ -134,6 +140,7 @@ class Example extends PureComponent {
               xvizStyles={XVIZ_STYLE}
               showTooltip={settings.showTooltip}
               viewMode={VIEW_MODE[settings.viewMode]}
+              debug={payload => this.setState({statsSnapshot: payload})}
             />
             <div id="hud">
               <TurnSignalWidget log={log} streamName="/vehicle/turn_signal" />

--- a/test/apps/viewer/src/app.js
+++ b/test/apps/viewer/src/app.js
@@ -34,7 +34,7 @@ import {
   XVIZPanel,
   VIEW_MODE
 } from 'streetscape.gl';
-import {XvizWorkersStatus, LogViewerStats} from '@streetscape.gl';
+import {XVIZWorkersStatus, LogViewerStats} from '@streetscape.gl';
 import {Form} from '@streetscape.gl/monochrome';
 
 import {XVIZ_CONFIG, APP_SETTINGS, MAPBOX_TOKEN, MAP_STYLE, XVIZ_STYLE, CAR} from './constants';
@@ -126,7 +126,7 @@ class Example extends PureComponent {
           />
           <StreamSettingsPanel log={log} />
           <hr />
-          <XvizWorkersStatus log={log} />
+          <XVIZWorkersStatus log={log} />
           <hr />
           <LogViewerStats statsSnapshot={statsSnapshot} />
         </div>

--- a/test/apps/viewer/src/app.js
+++ b/test/apps/viewer/src/app.js
@@ -32,9 +32,10 @@ import {
   TrafficLightWidget,
   TurnSignalWidget,
   XVIZPanel,
-  VIEW_MODE
+  VIEW_MODE,
+  XVIZWorkersStatus,
+  LogViewerStats
 } from 'streetscape.gl';
-import {XVIZWorkersStatus, LogViewerStats} from '@streetscape.gl';
 import {Form} from '@streetscape.gl/monochrome';
 
 import {XVIZ_CONFIG, APP_SETTINGS, MAPBOX_TOKEN, MAP_STYLE, XVIZ_STYLE, CAR} from './constants';

--- a/test/apps/viewer/src/constants.js
+++ b/test/apps/viewer/src/constants.js
@@ -45,6 +45,10 @@ export const APP_SETTINGS = {
   showTooltip: {
     type: 'toggle',
     title: 'Show Tooltip'
+  },
+  showDebug: {
+    type: 'toggle',
+    title: 'Show Debug Stats'
   }
 };
 


### PR DESCRIPTION
Added a new debug panel with `@xviz/parser`worker farm status + `LogViewer` stats chart:

<img width="1680" alt="Screen Shot 2019-04-28 at 9 37 55 PM" src="https://user-images.githubusercontent.com/2488251/56877153-e2da1c80-6a00-11e9-9d5f-7db1ef327922.png">

Note:  an `XVIZWorkersMonitor` instance (called `monitor`) keeps track of the XVIZ worker farm status. When `monitor.update()` is called, the workers status gets updated. This method is passed as a callback to `@xviz/parser`'s `parseStreamMessage` via the `debug` callback argument. When the debug callback is called, the XVIZ workers status are updated in the monitor. This allows us to decorrelate the rate at which the monitor workers status gets updated (on each message by  `parseStreamMessage`) from the rate at which a view component is updated (here `XvizWorkersStatus` via the monitor's `reportCallback`). We don't want the view component to re-render on every incoming un-parsed XVIZ message, this would be too heavy.