### PR TITLE
Fix black video image being drawn while image promise is pending

### DIFF
--- a/modules/core/src/components/declarative-ui/image-sequence.js
+++ b/modules/core/src/components/declarative-ui/image-sequence.js
@@ -79,7 +79,8 @@ export default class ImageSequence extends PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      this.state.currentFrameImage !== prevState.currentFrameImage ||
+      (this.state.currentFrameImage !== prevState.currentFrameImage &&
+        !this.state.currentFrameImagePending) ||
       this.state.width !== prevState.width ||
       this.state.height !== prevState.height
     ) {
@@ -108,13 +109,17 @@ export default class ImageSequence extends PureComponent {
     if (currentFrameData && !currentFrameData.image) {
       currentFrameData.promise.then(image => {
         if (this.state.currentFrame === currentFrame) {
-          this.setState({currentFrameImage: image});
+          this.setState({
+            currentFrameImagePending: false,
+            currentFrameImage: image
+          });
         }
       });
     }
 
     return {
       currentFrameImage: currentFrameData && currentFrameData.image,
+      currentFrameImagePending: currentFrameData && !currentFrameData.image && true,
       currentFrame
     };
   }


### PR DESCRIPTION
When a new JPEG encoded frame is transmitted via XVIZ the video
display jumps to a black image for a split second before the new
actual image is drawn. This commit prevents redrawing of the video
image while a (decoding?) promise is pending.