### PR TITLE
disable doubleclicking on mapview

### DIFF
--- a/modules/core/src/utils/viewport.js
+++ b/modules/core/src/utils/viewport.js
@@ -67,7 +67,7 @@ function offsetViewState(viewState, offset) {
 export function getViews(viewMode) {
   const {name, orthographic, firstPerson, mapInteraction} = viewMode;
 
-  const controllerProps = {...mapInteraction, keyboard: false};
+  const controllerProps = {...mapInteraction, doubleClickZoom: false, keyboard: false};
 
   if (firstPerson) {
     return new FirstPersonView({


### PR DESCRIPTION
Disable doubleclickzoom behavior on the mapview since this is behaving erratically