### PR TITLE
Support collapsing in stream settings panel

### DIFF
--- a/modules/core/src/components/stream-settings-panel.js
+++ b/modules/core/src/components/stream-settings-panel.js
@@ -60,7 +60,7 @@ export function createFormData(metadata, opts) {
   }
 
   const root = {};
-  const {style = {}} = opts;
+  const {style = {}, collapsible = false} = opts;
 
   for (const streamName in metadata) {
     const parentKey = getParentKey(streamName);
@@ -70,6 +70,7 @@ export function createFormData(metadata, opts) {
       root[parentKey] = root[parentKey] || {
         type: 'checkbox',
         children: {},
+        collapsible,
         badge: <Badge userStyle={style.badge} />
       };
       siblings = root[parentKey].children;

--- a/test/modules/core/components/stream-settings-panel.spec.js
+++ b/test/modules/core/components/stream-settings-panel.spec.js
@@ -48,11 +48,32 @@ const TEST_STREAMS = {
 test('StreamSettingsPanel#createFormData', t => {
   const data = createFormData(TEST_STREAMS, {});
 
+  t.equals(data['/vehicle_pose'].collapsible, undefined);
   t.deepEquals(
     Object.keys(data),
     ['/vehicle_pose', '/vehicle', '/lidar'],
     'extracted top-level options'
   );
+  t.equals(data['/vehicle'].collapsible, undefined);
+  t.deepEquals(
+    Object.keys(data['/vehicle'].children),
+    ['/vehicle/velocity', '/vehicle/acceleration'],
+    'extracted nested options'
+  );
+
+  t.end();
+});
+
+test.only('StreamSettingsPanel#createFormData-collapsible', t => {
+  const data = createFormData(TEST_STREAMS, {collapsible: true});
+
+  t.equals(data['/vehicle_pose'].collapsible, undefined);
+  t.deepEquals(
+    Object.keys(data),
+    ['/vehicle_pose', '/vehicle', '/lidar'],
+    'extracted top-level options'
+  );
+  t.equals(data['/vehicle'].collapsible, true);
   t.deepEquals(
     Object.keys(data['/vehicle'].children),
     ['/vehicle/velocity', '/vehicle/acceleration'],


### PR DESCRIPTION
This makes dealing with larges numbers of stream more manageable.
It only allows for collapsing the first level, but that is a great start.