### PR TITLE
Add new link that points to docs relating to running the Starter Kit

### DIFF
--- a/examples/get-started/README.md
+++ b/examples/get-started/README.md
@@ -2,4 +2,4 @@
 
 This is a minimal example that uses the components from streetscape.gl to display a XVIZ log.
 
-[Instructions for running this application](docs/get-started/xviz-viewer.md)
+[Instructions for running this application](../../docs/get-started/starter-kit.md)


### PR DESCRIPTION
Point users to the Starter Kit instruction docs.