### PR TITLE
Update the isLoading variable to check against undefined and null values

### DIFF
--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -127,7 +127,7 @@ class XVIZMetricComponent extends PureComponent {
       verticalGridLines,
       getColor
     } = this.props;
-    const isLoading = currentTime === null || currentTime === undefined;
+    const isLoading = currentTime == null; /* eslint-disable-line no-eq-null, eqeqeq */
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
 
     return (

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -127,7 +127,7 @@ class XVIZMetricComponent extends PureComponent {
       verticalGridLines,
       getColor
     } = this.props;
-    const isLoading = currentTime === null;
+    const isLoading = currentTime === null || currentTime === undefined;
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
 
     return (


### PR DESCRIPTION
At the moment, `isLoading` is checking to see if there is a `currentTime` in order to determine whether or not to display a metric. As `currentTime` is declared but does not have a value (until it's passed in as a prop) it needs to be checked against `undefined` as well. 