### PR TITLE
stream settings parent always has a field for children

### DIFF
--- a/modules/core/src/components/stream-settings-panel.js
+++ b/modules/core/src/components/stream-settings-panel.js
@@ -67,12 +67,15 @@ export function createFormData(metadata, opts) {
     let siblings = root;
 
     if (parentKey) {
-      root[parentKey] = root[parentKey] || {
-        type: 'checkbox',
-        children: {},
-        collapsible,
-        badge: <Badge userStyle={style.badge} />
-      };
+      const hasValidParent = Boolean(root[parentKey] && root[parentKey].children);
+      root[parentKey] = hasValidParent
+        ? root[parentKey]
+        : {
+            type: 'checkbox',
+            children: {},
+            collapsible,
+            badge: <Badge userStyle={style.badge} />
+          };
       siblings = root[parentKey].children;
     }
 


### PR DESCRIPTION
Previous code throws an exception if the parent is added before any children. The parent node is defined, but doesn't have an object assigned to children. This just adds an additional check.