### PR TITLE
Support dynamic stream metadata

### DIFF
--- a/docs/api-reference/connect-to-log.md
+++ b/docs/api-reference/connect-to-log.md
@@ -1,8 +1,8 @@
 # connectToLog
 
 Wraps a React component in a
-[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when a
-[XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
+[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when
+a [XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
 
 ```jsx
 // some-container.js

--- a/docs/api-reference/log-viewer.md
+++ b/docs/api-reference/log-viewer.md
@@ -293,3 +293,7 @@ The current frame of the log.
 ##### metadata (Object)
 
 The metadata of the log.
+
+##### streamMetadata (Object)
+
+A map from stream names to their metadata.

--- a/docs/api-reference/log-viewer.md
+++ b/docs/api-reference/log-viewer.md
@@ -294,6 +294,6 @@ The current frame of the log.
 
 The metadata of the log.
 
-##### streamMetadata (Object)
+##### streamsMetadata (Object)
 
 A map from stream names to their metadata.

--- a/docs/api-reference/xviz-loader-interface.md
+++ b/docs/api-reference/xviz-loader-interface.md
@@ -76,6 +76,10 @@ Returns the current look ahead offset in seconds.
 
 Returns the loaded metadata.
 
+##### getStreamMetadata()
+
+Returns a map from stream names to stream metadata.
+
 ##### getStreamSettings()
 
 Returns the current stream settings.

--- a/docs/api-reference/xviz-metric.md
+++ b/docs/api-reference/xviz-metric.md
@@ -108,7 +108,7 @@ store:
 
 The current playback position of the log.
 
-##### streamMetadata (Object)
+##### streamsMetadata (Object)
 
 A map from stream names to their metadata.
 

--- a/docs/api-reference/xviz-metric.md
+++ b/docs/api-reference/xviz-metric.md
@@ -108,9 +108,9 @@ store:
 
 The current playback position of the log.
 
-##### metadata (Object)
+##### streamMetadata (Object)
 
-The log metadata.
+A map from stream names to their metadata.
 
 ##### logStreams (Object)
 

--- a/docs/api-reference/xviz-plot.md
+++ b/docs/api-reference/xviz-plot.md
@@ -100,7 +100,7 @@ The following props are automatically populated when the `log` prop is provided.
 manually if the component is used without a `XVIZLoader` instance, e.g. connected with a Redux
 store:
 
-##### streamMetadata (Object)
+##### streamsMetadata (Object)
 
 A map from stream names to their metadata.
 

--- a/docs/api-reference/xviz-plot.md
+++ b/docs/api-reference/xviz-plot.md
@@ -100,9 +100,9 @@ The following props are automatically populated when the `log` prop is provided.
 manually if the component is used without a `XVIZLoader` instance, e.g. connected with a Redux
 store:
 
-##### metadata (Object)
+##### streamMetadata (Object)
 
-The metadata of the current log.
+A map from stream names to their metadata.
 
 ##### variables (Object)
 

--- a/docs/api-reference/xviz-video.md
+++ b/docs/api-reference/xviz-video.md
@@ -53,7 +53,7 @@ store:
 
 The current playback position of the log.
 
-##### streamMetadata (Object)
+##### streamsMetadata (Object)
 
 A map from stream names to their metadata.
 

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -51,7 +51,7 @@ class XVIZMetricComponent extends PureComponent {
 
     // From connected log
     currentTime: PropTypes.number,
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     logStreams: PropTypes.objectOf(PropTypes.array),
     startTime: PropTypes.number,
     endTime: PropTypes.number
@@ -82,7 +82,7 @@ class XVIZMetricComponent extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (
       this.props.streams !== nextProps.streams ||
-      this.props.streamMetadata !== nextProps.streamMetadata ||
+      this.props.streamsMetadata !== nextProps.streamsMetadata ||
       this.props.logStreams !== nextProps.logStreams
     ) {
       this.setState({
@@ -94,7 +94,7 @@ class XVIZMetricComponent extends PureComponent {
   _getTimeSeries(props) {
     return getTimeSeries({
       streamNames: props.streams,
-      streamMetadata: props.streamMetadata,
+      streamsMetadata: props.streamsMetadata,
       streams: props.logStreams
     });
   }
@@ -158,7 +158,7 @@ class XVIZMetricComponent extends PureComponent {
 
 const getLogState = log => ({
   currentTime: log.getCurrentTime(),
-  streamMetadata: log.getStreamMetadata(),
+  streamsMetadata: log.getStreamsMetadata(),
   logStreams: log.getStreams(),
   startTime: log.getBufferStartTime(),
   endTime: log.getBufferEndTime()

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -51,7 +51,7 @@ class XVIZMetricComponent extends PureComponent {
 
     // From connected log
     currentTime: PropTypes.number,
-    metadata: PropTypes.object,
+    streamMetadata: PropTypes.object,
     logStreams: PropTypes.objectOf(PropTypes.array),
     startTime: PropTypes.number,
     endTime: PropTypes.number
@@ -82,7 +82,7 @@ class XVIZMetricComponent extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (
       this.props.streams !== nextProps.streams ||
-      this.props.metadata !== nextProps.metadata ||
+      this.props.streamMetadata !== nextProps.streamMetadata ||
       this.props.logStreams !== nextProps.logStreams
     ) {
       this.setState({
@@ -94,7 +94,7 @@ class XVIZMetricComponent extends PureComponent {
   _getTimeSeries(props) {
     return getTimeSeries({
       streamNames: props.streams,
-      metadata: props.metadata,
+      streamMetadata: props.streamMetadata,
       streams: props.logStreams
     });
   }
@@ -158,7 +158,7 @@ class XVIZMetricComponent extends PureComponent {
 
 const getLogState = log => ({
   currentTime: log.getCurrentTime(),
-  metadata: log.getMetadata(),
+  streamMetadata: log.getStreamMetadata(),
   logStreams: log.getStreams(),
   startTime: log.getBufferStartTime(),
   endTime: log.getBufferEndTime()

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -51,12 +51,12 @@ class XVIZPlotComponent extends PureComponent {
     dependentVariables: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
-    metadata: PropTypes.object,
+    streamMetadata: PropTypes.object,
     variables: PropTypes.object
   };
 
   static defaultProps = {
-    metadata: {},
+    streamMetadata: {},
     variables: {},
     width: '100%',
     height: 300,
@@ -217,7 +217,7 @@ class XVIZPlotComponent extends PureComponent {
 const getLogState = log => {
   const frame = log.getCurrentFrame();
   return {
-    metadata: log.getMetadata(),
+    streamMetadata: log.getStreamMetadata(),
     variables: frame && frame.variables
   };
 };

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -51,12 +51,12 @@ class XVIZPlotComponent extends PureComponent {
     dependentVariables: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     variables: PropTypes.object
   };
 
   static defaultProps = {
-    streamMetadata: {},
+    streamsMetadata: {},
     variables: {},
     width: '100%',
     height: 300,
@@ -217,7 +217,7 @@ class XVIZPlotComponent extends PureComponent {
 const getLogState = log => {
   const frame = log.getCurrentFrame();
   return {
-    streamMetadata: log.getStreamMetadata(),
+    streamsMetadata: log.getStreamsMetadata(),
     variables: frame && frame.variables
   };
 };

--- a/modules/core/src/components/declarative-ui/xviz-video.js
+++ b/modules/core/src/components/declarative-ui/xviz-video.js
@@ -153,14 +153,11 @@ class BaseComponent extends PureComponent {
   }
 }
 
-const getLogState = log => {
-  const metadata = log.getMetadata();
-  return {
-    currentTime: log.getCurrentTime(),
-    streamMetadata: metadata && metadata.streams,
-    streams: log.getStreams()
-  };
-};
+const getLogState = log => ({
+  currentTime: log.getCurrentTime(),
+  streamMetadata: log.getStreamMetadata(),
+  streams: log.getStreams()
+});
 
 const XVIZVideoComponent = withTheme(BaseComponent);
 

--- a/modules/core/src/components/declarative-ui/xviz-video.js
+++ b/modules/core/src/components/declarative-ui/xviz-video.js
@@ -51,7 +51,7 @@ class BaseComponent extends PureComponent {
 
     // From connected log
     currentTime: PropTypes.number,
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     streams: PropTypes.object
   };
 
@@ -71,29 +71,19 @@ class BaseComponent extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     if (
-      this.props.streamMetadata !== nextProps.streamMetadata ||
+      this.props.streamsMetadata !== nextProps.streamsMetadata ||
       this.props.cameras !== nextProps.cameras
     ) {
       this.setState(this._getStreamNames(nextProps));
     }
   }
 
-  _getStreamNames({streamMetadata, cameras}) {
-    if (!streamMetadata) {
-      return {
-        streamNames: null,
-        selectedStreamName: null
-      };
-    }
-
-    const streamNames = Object.keys(streamMetadata)
-      .filter(
-        streamName =>
-          streamMetadata[streamName] &&
-          streamMetadata[streamName].primitive_type &&
-          (streamMetadata[streamName].primitive_type === 'IMAGE' ||
-            streamMetadata[streamName].primitive_type === 'image') // Support pre-1.0 lowercase value
-      )
+  _getStreamNames({streamsMetadata, cameras}) {
+    const streamNames = Object.keys(streamsMetadata)
+      .filter(streamName => {
+        const type = streamsMetadata[streamName] && streamsMetadata[streamName].primitive_type;
+        return type === 'IMAGE' || type === 'image'; // Support pre-1.0 lowercase value
+      })
       .filter(normalizeStreamFilter(cameras))
       .sort();
     let {selectedStreamName} = this.state || {};
@@ -155,7 +145,7 @@ class BaseComponent extends PureComponent {
 
 const getLogState = log => ({
   currentTime: log.getCurrentTime(),
-  streamMetadata: log.getStreamMetadata(),
+  streamsMetadata: log.getStreamsMetadata(),
   streams: log.getStreams()
 });
 

--- a/modules/core/src/components/hud/base-widget.js
+++ b/modules/core/src/components/hud/base-widget.js
@@ -39,7 +39,7 @@ class BaseWidget extends PureComponent {
     children: PropTypes.func.isRequired,
 
     // From connected log
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     frame: PropTypes.object
   };
 
@@ -57,20 +57,20 @@ class BaseWidget extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (
       nextProps.streamNames !== this.props.streamNames ||
-      nextProps.streamMetadata !== this.props.streamMetadata ||
+      nextProps.streamsMetadata !== this.props.streamsMetadata ||
       nextProps.frame !== this.props.frame
     ) {
       this.setState({streams: this._extractStreams(nextProps)});
     }
   }
 
-  _extractStreams({streamNames, streamMetadata, frame}) {
+  _extractStreams({streamNames, streamsMetadata, frame}) {
     const result = {};
     for (const key in streamNames) {
       const streamName = streamNames[key];
       if (streamName) {
         result[key] = {
-          ...(streamMetadata && streamMetadata[streamName]),
+          ...streamsMetadata[streamName],
           data: frame && frame.streams[streamName]
         };
       }
@@ -91,7 +91,7 @@ class BaseWidget extends PureComponent {
 }
 
 const getLogState = log => ({
-  streamMetadata: log.getStreamMetadata(),
+  streamsMetadata: log.getStreamsMetadata(),
   frame: log.getCurrentFrame()
 });
 

--- a/modules/core/src/components/hud/base-widget.js
+++ b/modules/core/src/components/hud/base-widget.js
@@ -90,12 +90,9 @@ class BaseWidget extends PureComponent {
   }
 }
 
-const getLogState = (log, {streamName}) => {
-  const metadata = log.getMetadata();
-  return {
-    streamMetadata: metadata && metadata.streams,
-    frame: log.getCurrentFrame()
-  };
-};
+const getLogState = log => ({
+  streamMetadata: log.getStreamMetadata(),
+  frame: log.getCurrentFrame()
+});
 
 export default connectToLog({getLogState, Component: withTheme(BaseWidget)});

--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -55,7 +55,7 @@ export default class Core3DViewer extends PureComponent {
     // Props from loader
     frame: PropTypes.object,
     metadata: PropTypes.object,
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
 
     // Rendering options
     showMap: PropTypes.bool,
@@ -232,7 +232,7 @@ export default class Core3DViewer extends PureComponent {
   _getLayers() {
     const {
       frame,
-      streamMetadata,
+      streamsMetadata,
       showTooltip,
       objectStates,
       customLayers,
@@ -262,7 +262,7 @@ export default class Core3DViewer extends PureComponent {
           const stream = lookAheads[streamName] || streams[streamName];
           const coordinateProps = resolveCoordinateTransform(
             frame,
-            streamMetadata[streamName],
+            streamsMetadata[streamName],
             getTransformMatrix
           );
 
@@ -308,7 +308,11 @@ export default class Core3DViewer extends PureComponent {
           const stream = streams[props.streamName];
           Object.assign(
             additionalProps,
-            resolveCoordinateTransform(frame, streamMetadata[props.streamName], getTransformMatrix),
+            resolveCoordinateTransform(
+              frame,
+              streamsMetadata[props.streamName],
+              getTransformMatrix
+            ),
             {
               data: stream && stream.features
             }
@@ -363,7 +367,7 @@ export default class Core3DViewer extends PureComponent {
     const {
       mapboxApiAccessToken,
       frame,
-      streamMetadata,
+      streamsMetadata,
       objectStates,
       renderObjectLabel,
       getTransformMatrix,
@@ -405,7 +409,7 @@ export default class Core3DViewer extends PureComponent {
         <ObjectLabelsOverlay
           objectSelection={objectStates.selected}
           frame={frame}
-          streamMetadata={streamMetadata}
+          streamsMetadata={streamsMetadata}
           renderObjectLabel={renderObjectLabel}
           xvizStyleParser={styleParser}
           style={style}

--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -43,10 +43,6 @@ import {DEFAULT_ORIGIN, CAR_DATA, LIGHTS, DEFAULT_CAR} from './constants';
 
 const noop = () => {};
 
-function getStreamMetadata(metadata, streamName) {
-  return (metadata && metadata.streams && metadata.streams[streamName]) || {};
-}
-
 const Z_INDEX = {
   car: 0,
   point: 1,
@@ -59,6 +55,7 @@ export default class Core3DViewer extends PureComponent {
     // Props from loader
     frame: PropTypes.object,
     metadata: PropTypes.object,
+    streamMetadata: PropTypes.object,
 
     // Rendering options
     showMap: PropTypes.bool,
@@ -235,13 +232,13 @@ export default class Core3DViewer extends PureComponent {
   _getLayers() {
     const {
       frame,
-      metadata,
+      streamMetadata,
       showTooltip,
       objectStates,
       customLayers,
       getTransformMatrix
     } = this.props;
-    if (!frame || !metadata) {
+    if (!frame) {
       return [];
     }
 
@@ -263,10 +260,9 @@ export default class Core3DViewer extends PureComponent {
           // Check lookAheads first because it will contain the selected futures
           // while streams would contain the full futures array
           const stream = lookAheads[streamName] || streams[streamName];
-          const streamMetadata = getStreamMetadata(metadata, streamName);
           const coordinateProps = resolveCoordinateTransform(
             frame,
-            streamMetadata,
+            streamMetadata[streamName],
             getTransformMatrix
           );
 
@@ -310,10 +306,9 @@ export default class Core3DViewer extends PureComponent {
         if (props.streamName) {
           // Use log data
           const stream = streams[props.streamName];
-          const streamMetadata = getStreamMetadata(metadata, props.streamName);
           Object.assign(
             additionalProps,
-            resolveCoordinateTransform(frame, streamMetadata, getTransformMatrix),
+            resolveCoordinateTransform(frame, streamMetadata[props.streamName], getTransformMatrix),
             {
               data: stream && stream.features
             }
@@ -368,7 +363,7 @@ export default class Core3DViewer extends PureComponent {
     const {
       mapboxApiAccessToken,
       frame,
-      metadata,
+      streamMetadata,
       objectStates,
       renderObjectLabel,
       getTransformMatrix,
@@ -410,7 +405,7 @@ export default class Core3DViewer extends PureComponent {
         <ObjectLabelsOverlay
           objectSelection={objectStates.selected}
           frame={frame}
-          metadata={metadata}
+          streamMetadata={streamMetadata}
           renderObjectLabel={renderObjectLabel}
           xvizStyleParser={styleParser}
           style={style}

--- a/modules/core/src/components/log-viewer/index.js
+++ b/modules/core/src/components/log-viewer/index.js
@@ -36,10 +36,6 @@ class LogViewer extends PureComponent {
   static propTypes = {
     ...Core3DViewer.propTypes,
 
-    // Props from loader
-    frame: PropTypes.object,
-    metadata: PropTypes.object,
-
     // Rendering options
     renderTooltip: PropTypes.func,
     style: PropTypes.object,
@@ -165,7 +161,8 @@ class LogViewer extends PureComponent {
 
 const getLogState = log => ({
   frame: log.getCurrentFrame(),
-  metadata: log.getMetadata()
+  metadata: log.getMetadata(),
+  streamMetadata: log.getStreamMetadata()
 });
 
 export default connectToLog({getLogState, Component: LogViewer});

--- a/modules/core/src/components/log-viewer/index.js
+++ b/modules/core/src/components/log-viewer/index.js
@@ -162,7 +162,7 @@ class LogViewer extends PureComponent {
 const getLogState = log => ({
   frame: log.getCurrentFrame(),
   metadata: log.getMetadata(),
-  streamMetadata: log.getStreamMetadata()
+  streamsMetadata: log.getStreamsMetadata()
 });
 
 export default connectToLog({getLogState, Component: LogViewer});

--- a/modules/core/src/components/log-viewer/object-labels-overlay.js
+++ b/modules/core/src/components/log-viewer/object-labels-overlay.js
@@ -34,7 +34,7 @@ export default class ObjectLabelsOverlay extends PureComponent {
   static propTypes = {
     objectSelection: PropTypes.object,
     frame: PropTypes.object,
-    metadata: PropTypes.object,
+    streamMetadata: PropTypes.object,
     xvizStyleParser: PropTypes.object,
 
     renderObjectLabel: PropTypes.func,
@@ -73,9 +73,8 @@ export default class ObjectLabelsOverlay extends PureComponent {
       return result;
     }
 
-    const {frame, metadata, getTransformMatrix} = this.props;
-    const streamMetadata = metadata.streams && metadata.streams[streamName];
-    result = resolveCoordinateTransform(frame, streamMetadata, getTransformMatrix);
+    const {frame, streamMetadata, getTransformMatrix} = this.props;
+    result = resolveCoordinateTransform(frame, streamMetadata[streamName], getTransformMatrix);
     // cache calculated coordinate props by stream name
     coordinateProps[streamName] = result;
 

--- a/modules/core/src/components/log-viewer/object-labels-overlay.js
+++ b/modules/core/src/components/log-viewer/object-labels-overlay.js
@@ -34,7 +34,7 @@ export default class ObjectLabelsOverlay extends PureComponent {
   static propTypes = {
     objectSelection: PropTypes.object,
     frame: PropTypes.object,
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     xvizStyleParser: PropTypes.object,
 
     renderObjectLabel: PropTypes.func,
@@ -73,8 +73,8 @@ export default class ObjectLabelsOverlay extends PureComponent {
       return result;
     }
 
-    const {frame, streamMetadata, getTransformMatrix} = this.props;
-    result = resolveCoordinateTransform(frame, streamMetadata[streamName], getTransformMatrix);
+    const {frame, streamsMetadata, getTransformMatrix} = this.props;
+    result = resolveCoordinateTransform(frame, streamsMetadata[streamName], getTransformMatrix);
     // cache calculated coordinate props by stream name
     coordinateProps[streamName] = result;
 

--- a/modules/core/src/components/stream-settings-panel.js
+++ b/modules/core/src/components/stream-settings-panel.js
@@ -143,7 +143,7 @@ export function formValuesToSettings(metadata, values) {
 class StreamSettingsPanel extends PureComponent {
   static propTypes = {
     style: PropTypes.object,
-    streamMetadata: PropTypes.object,
+    streamsMetadata: PropTypes.object,
     onSettingsChange: PropTypes.func
   };
 
@@ -155,30 +155,29 @@ class StreamSettingsPanel extends PureComponent {
   constructor(props) {
     super(props);
 
-    const data = createFormData(props.streamMetadata, props);
+    const data = createFormData(props.streamsMetadata, props);
     const values = settingsToFormValues(data, props.streamSettings);
     this.state = {data, values};
   }
 
   componentWillReceiveProps(nextProps) {
     let {data, values} = this.state;
-    let dataChanged = false;
 
-    if (nextProps.streamMetadata !== this.props.streamMetadata) {
-      data = createFormData(nextProps.streamMetadata, nextProps);
-      dataChanged = true;
+    if (nextProps.streamsMetadata !== this.props.streamsMetadata) {
+      data = createFormData(nextProps.streamsMetadata, nextProps);
+      values = null;
     }
-    if (dataChanged || nextProps.streamSettings !== this.props.streamSettings) {
+    if (nextProps.streamSettings !== this.props.streamSettings) {
       values = settingsToFormValues(data, nextProps.streamSettings);
     }
     this.setState({data, values});
   }
 
   _onValuesChange = newValues => {
-    const {streamMetadata, log, onSettingsChange} = this.props;
+    const {streamsMetadata, log, onSettingsChange} = this.props;
     const {data} = this.state;
     const values = updateFormValues(data, this.state.values, newValues);
-    const settings = formValuesToSettings(streamMetadata, values);
+    const settings = formValuesToSettings(streamsMetadata, values);
 
     if (!onSettingsChange(settings) && log) {
       log.updateStreamSettings(settings);
@@ -198,7 +197,7 @@ class StreamSettingsPanel extends PureComponent {
 }
 
 const getLogState = log => ({
-  streamMetadata: log.getStreamMetadata(),
+  streamsMetadata: log.getStreamsMetadata(),
   streamSettings: log.getStreamSettings()
 });
 

--- a/modules/core/src/components/stream-settings-panel.js
+++ b/modules/core/src/components/stream-settings-panel.js
@@ -162,12 +162,13 @@ class StreamSettingsPanel extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     let {data, values} = this.state;
+    let dataChanged = false;
 
     if (nextProps.streamMetadata !== this.props.streamMetadata) {
       data = createFormData(nextProps.streamMetadata, nextProps);
-      values = null;
+      dataChanged = true;
     }
-    if (nextProps.streamSettings !== this.props.streamSettings) {
+    if (dataChanged || nextProps.streamSettings !== this.props.streamSettings) {
       values = settingsToFormValues(data, nextProps.streamSettings);
     }
     this.setState({data, values});
@@ -196,12 +197,9 @@ class StreamSettingsPanel extends PureComponent {
   }
 }
 
-const getLogState = log => {
-  const metadata = log.getMetadata();
-  return {
-    streamMetadata: metadata && metadata.streams,
-    streamSettings: log.getStreamSettings()
-  };
-};
+const getLogState = log => ({
+  streamMetadata: log.getStreamMetadata(),
+  streamSettings: log.getStreamSettings()
+});
 
 export default connectToLog({getLogState, Component: StreamSettingsPanel});

--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -174,7 +174,7 @@ export default class XVIZLoaderInterface {
 
   _getDataVersion = () => this.get('dataVersion');
 
-  _getStreamMetadata = () => this.get('streamMetadata');
+  _getStreamsMetadata = () => this.get('streamsMetadata');
 
   _getStreams = createSelector(this, this._getDataVersion, () => this._getDataByStream());
 
@@ -199,12 +199,12 @@ export default class XVIZLoaderInterface {
     }
   );
 
-  getStreamMetadata = getXVIZConfig().DYNAMIC_STREAM_METADATA
+  getStreamsMetadata = getXVIZConfig().DYNAMIC_STREAM_METADATA
     ? createSelector(
         this,
-        [this.getMetadata, this._getStreamMetadata],
-        (metadata, streamMetadata) => {
-          return Object.assign({}, streamMetadata, metadata && metadata.streams);
+        [this.getMetadata, this._getStreamsMetadata],
+        (metadata, streamsMetadata) => {
+          return Object.assign({}, streamsMetadata, metadata && metadata.streams);
         }
       )
     : createSelector(this, this.getMetadata, metadata => (metadata && metadata.streams) || {});
@@ -272,11 +272,18 @@ export default class XVIZLoaderInterface {
     }
 
     if (getXVIZConfig().DYNAMIC_STREAM_METADATA && this.streamBuffer.streamCount > oldStreamCount) {
-      const streamMetadata = {};
+      const streamsMetadata = {};
+      const streamSettings = this.get('streamSettings');
+
       for (const streamName in timeslice.streams) {
-        streamMetadata[streamName] = timeslice.streams[streamName].__metadata;
+        streamsMetadata[streamName] = timeslice.streams[streamName].__metadata;
+
+        // Add new stream name to stream settings (default on)
+        if (!(streamName in streamSettings)) {
+          streamSettings[streamName] = true;
+        }
       }
-      this.set('streamMetadata', streamMetadata);
+      this.set('streamsMetadata', streamsMetadata);
     }
 
     return bufferUpdated;

--- a/modules/core/src/utils/metrics-helper.js
+++ b/modules/core/src/utils/metrics-helper.js
@@ -48,17 +48,17 @@ function getTimeSeriesForStream(streamName, metadata, stream, target) {
  * @param streams array of streams data
  * @returns {Array} array of time series data
  */
-export function getTimeSeries({metadata = {}, streamNames, streams}) {
+export function getTimeSeries({streamMetadata = {}, streamNames, streams}) {
   const timeSeries = {
     isLoading: true,
     data: {}
   };
   for (const streamName of streamNames) {
     // ui configuration for this stream
-    const streamMetadata = (metadata.streams && metadata.streams[streamName]) || {};
+    const metadata = (streamMetadata && streamMetadata[streamName]) || {};
     const stream = streams[streamName];
     if (stream) {
-      getTimeSeriesForStream(streamName, streamMetadata, stream, timeSeries);
+      getTimeSeriesForStream(streamName, metadata, stream, timeSeries);
     }
   }
 

--- a/modules/core/src/utils/metrics-helper.js
+++ b/modules/core/src/utils/metrics-helper.js
@@ -44,21 +44,21 @@ function getTimeSeriesForStream(streamName, metadata, stream, target) {
 
 /**
  * Get the time series for given streams
- * @param logMetadata {object} log metadata
+ * @param streamsMetadata {object} map from stream names to stream metadata
  * @param streams array of streams data
  * @returns {Array} array of time series data
  */
-export function getTimeSeries({streamMetadata = {}, streamNames, streams}) {
+export function getTimeSeries({streamsMetadata = {}, streamNames, streams}) {
   const timeSeries = {
     isLoading: true,
     data: {}
   };
   for (const streamName of streamNames) {
     // ui configuration for this stream
-    const metadata = (streamMetadata && streamMetadata[streamName]) || {};
+    const streamMetadata = (streamsMetadata && streamsMetadata[streamName]) || {};
     const stream = streams[streamName];
     if (stream) {
-      getTimeSeriesForStream(streamName, metadata, stream, timeSeries);
+      getTimeSeriesForStream(streamName, streamMetadata, stream, timeSeries);
     }
   }
 

--- a/test/modules/core/utils/metrics-helper.spec.js
+++ b/test/modules/core/utils/metrics-helper.spec.js
@@ -23,21 +23,19 @@ import test from 'tape';
 import {getTimeSeries} from '@streetscape.gl/core/utils/metrics-helper';
 
 test('metricsHelper#getTimeSeries', t => {
-  const metadata = {
-    streams: {
-      '/numerical': {
-        unit: 'mph',
-        scale: 2.23694
-      },
-      '/no_graph': {
-        nograph: true
-      },
-      '/value_map': {
-        valueMap: {left: -1, none: 0, right: 1}
-      },
-      '/empty': {
-        unit: 'rad'
-      }
+  const streamMetadata = {
+    '/numerical': {
+      unit: 'mph',
+      scale: 2.23694
+    },
+    '/no_graph': {
+      nograph: true
+    },
+    '/value_map': {
+      valueMap: {left: -1, none: 0, right: 1}
+    },
+    '/empty': {
+      unit: 'rad'
     }
   };
 
@@ -63,28 +61,28 @@ test('metricsHelper#getTimeSeries', t => {
     '/empty': [undefined, undefined, undefined, undefined]
   };
 
-  let result = getTimeSeries({metadata, streamNames: [], streams});
+  let result = getTimeSeries({streamMetadata, streamNames: [], streams});
   t.deepEqual(result.data, {}, 'Should return empty when no streams are requested.');
 
   result = getTimeSeries({streamNames: ['/numerical'], streams});
   t.ok(result.data['/numerical'], 'Should work without metadata');
 
-  result = getTimeSeries({metadata, streamNames: ['/numerical'], streams});
+  result = getTimeSeries({streamMetadata, streamNames: ['/numerical'], streams});
   t.is(result.getX(result.data['/numerical'][0]), 1000, 'getX is properly set');
   t.is(result.getY(result.data['/numerical'][0]), 2.23694, 'getY is properly set');
   t.is(result.unit, 'mph', 'unit is properly set');
   t.ok(result.data['/numerical'].every(Boolean), 'Missing frames are filtered out');
   t.notOk(result.isLoading, 'Should not show spinner');
 
-  result = getTimeSeries({metadata, streamNames: ['/no_graph'], streams});
+  result = getTimeSeries({streamMetadata, streamNames: ['/no_graph'], streams});
   t.deepEqual(result.data, {}, 'Should respect metadata setting');
   t.ok(result.isLoading, 'Should show spinner when no stream is available');
 
-  result = getTimeSeries({metadata, streamNames: ['/value_map'], streams});
+  result = getTimeSeries({streamMetadata, streamNames: ['/value_map'], streams});
   t.is(result.getY(result.data['/value_map'][0]), -1, 'getY is properly set for custom mapping');
   t.notOk(result.isLoading, 'Should not show spinner');
 
-  result = getTimeSeries({metadata, streamNames: ['/empty'], streams});
+  result = getTimeSeries({streamMetadata, streamNames: ['/empty'], streams});
   t.deepEqual(result.data, {}, 'Should return empty when no valid frames are found');
   t.ok(result.isLoading, 'Should show spinner when no stream is available');
 

--- a/test/modules/core/utils/metrics-helper.spec.js
+++ b/test/modules/core/utils/metrics-helper.spec.js
@@ -23,7 +23,7 @@ import test from 'tape';
 import {getTimeSeries} from '@streetscape.gl/core/utils/metrics-helper';
 
 test('metricsHelper#getTimeSeries', t => {
-  const streamMetadata = {
+  const streamsMetadata = {
     '/numerical': {
       unit: 'mph',
       scale: 2.23694
@@ -61,28 +61,28 @@ test('metricsHelper#getTimeSeries', t => {
     '/empty': [undefined, undefined, undefined, undefined]
   };
 
-  let result = getTimeSeries({streamMetadata, streamNames: [], streams});
+  let result = getTimeSeries({streamsMetadata, streamNames: [], streams});
   t.deepEqual(result.data, {}, 'Should return empty when no streams are requested.');
 
   result = getTimeSeries({streamNames: ['/numerical'], streams});
   t.ok(result.data['/numerical'], 'Should work without metadata');
 
-  result = getTimeSeries({streamMetadata, streamNames: ['/numerical'], streams});
+  result = getTimeSeries({streamsMetadata, streamNames: ['/numerical'], streams});
   t.is(result.getX(result.data['/numerical'][0]), 1000, 'getX is properly set');
   t.is(result.getY(result.data['/numerical'][0]), 2.23694, 'getY is properly set');
   t.is(result.unit, 'mph', 'unit is properly set');
   t.ok(result.data['/numerical'].every(Boolean), 'Missing frames are filtered out');
   t.notOk(result.isLoading, 'Should not show spinner');
 
-  result = getTimeSeries({streamMetadata, streamNames: ['/no_graph'], streams});
+  result = getTimeSeries({streamsMetadata, streamNames: ['/no_graph'], streams});
   t.deepEqual(result.data, {}, 'Should respect metadata setting');
   t.ok(result.isLoading, 'Should show spinner when no stream is available');
 
-  result = getTimeSeries({streamMetadata, streamNames: ['/value_map'], streams});
+  result = getTimeSeries({streamsMetadata, streamNames: ['/value_map'], streams});
   t.is(result.getY(result.data['/value_map'][0]), -1, 'getY is properly set for custom mapping');
   t.notOk(result.isLoading, 'Should not show spinner');
 
-  result = getTimeSeries({streamMetadata, streamNames: ['/empty'], streams});
+  result = getTimeSeries({streamsMetadata, streamNames: ['/empty'], streams});
   t.deepEqual(result.data, {}, 'Should return empty when no valid frames are found');
   t.ok(result.isLoading, 'Should show spinner when no stream is available');
 


### PR DESCRIPTION
### Change List

- Add `getStreamMetadata` to `XVIZLoaderInterface`
- Build local stream metadata if `DYNAMIC_STREAM_METADATA` config is set (requires https://github.com/uber/xviz/pull/493)
- Switch core components to use `getStreamMetadata` instead of `getMetadata().streams`