### PR TITLE
Add missing stream data component

### DIFF
--- a/docs/api-reference/connect-to-log.md
+++ b/docs/api-reference/connect-to-log.md
@@ -1,8 +1,8 @@
 # connectToLog
 
 Wraps a React component in a
-[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when a
-[XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
+[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when
+a [XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
 
 ```jsx
 // some-container.js

--- a/docs/api-reference/xviz-metric.md
+++ b/docs/api-reference/xviz-metric.md
@@ -33,7 +33,7 @@ Custom CSS overrides. Supports all
 [MetricCard](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling)
 and
 [MetricChart](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling-1)
-options.
+options. Supports `missingData` option as an override to `MissingDataCard` component.
 
 ##### getColor (Object|Function|String, optional)
 

--- a/docs/api-reference/xviz-metric.md
+++ b/docs/api-reference/xviz-metric.md
@@ -33,7 +33,9 @@ Custom CSS overrides. Supports all
 [MetricCard](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling)
 and
 [MetricChart](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling-1)
-options. Supports `missingData` option as an override to `MissingDataCard` component.
+options, plus the following fields:
+
+- `missingData`: CSS overrides for the "missing data" message
 
 ##### getColor (Object|Function|String, optional)
 

--- a/docs/api-reference/xviz-plot.md
+++ b/docs/api-reference/xviz-plot.md
@@ -33,7 +33,7 @@ Custom CSS overrides. Supports all
 [MetricChart](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling-1)
 and
 [RichMetricChart](https://github.com/uber-web/monochrome/blob/master/src/metric-card/README.md#styling-2)
-options.
+options. Supports `missingData` option as an override to `MissingDataCard` component.
 
 ##### getColor (Object|Function|String, optional)
 

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -20,7 +20,7 @@
     "@deck.gl/layers": "^7.1.2",
     "@deck.gl/mesh-layers": "^7.1.2",
     "@deck.gl/react": "^7.1.2",
-    "@streetscape.gl/monochrome": "^1.0.0-beta.3",
+    "@streetscape.gl/monochrome": "^1.0.0-beta.4",
     "@xviz/parser": "^1.0.0-beta.16",
     "lodash.merge": "^4.6.1",
     "math.gl": "^2.3.1",

--- a/modules/core/src/components/declarative-ui/missing-data-card.js
+++ b/modules/core/src/components/declarative-ui/missing-data-card.js
@@ -19,23 +19,24 @@
 // THE SOFTWARE.
 import React from 'react';
 import {Tooltip} from '@streetscape.gl/monochrome';
+import styled from '@emotion/styled';
+
+const WrapperComponent = styled.div(() => ({
+  color: 'red',
+  padding: '10px 0',
+  width: '350px',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+}));
 
 export const MissingDataCard = props => {
   const {missingData} = props;
   const missingDataAsString = missingData.join(', ');
-  const style = {
-    color: 'red',
-    padding: '10px 0',
-    maxWidth: '100%',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis'
-  };
 
   return (
-    <div style={style}>
-      <Tooltip style={props.style.tooltip} content={missingDataAsString}>
-        Missing Data: {missingDataAsString}
-      </Tooltip>
-    </div>
+    <Tooltip style={props.style.tooltip} content={missingDataAsString}>
+      <WrapperComponent>Missing Data: {missingDataAsString}</WrapperComponent>
+    </Tooltip>
   );
 };

--- a/modules/core/src/components/declarative-ui/missing-data-card.js
+++ b/modules/core/src/components/declarative-ui/missing-data-card.js
@@ -18,29 +18,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import React from 'react';
-import {evaluateStyle, Tooltip} from '@streetscape.gl/monochrome';
+import {evaluateStyle, Tooltip, withTheme} from '@streetscape.gl/monochrome';
 import styled from '@emotion/styled';
 
 const Container = styled.div(props => ({
   ...props.theme.__reset__,
-  color: 'red',
-  padding: '10px 0',
-  width: '350px',
-  whiteSpace: 'nowrap',
+  color: props.theme.warning400,
+  padding: props.theme.spacingNormal,
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
   ...evaluateStyle(props.userStyle, props)
 }));
 
-export const MissingDataCard = props => {
+const MissingDataCardBase = props => {
   const {missingData, theme, style} = props;
   const missingDataAsString = missingData.join(', ');
 
   return (
-    <Tooltip style={props.style.tooltip} content={missingDataAsString}>
-      <Container theme={theme} userStyle={style.missingData}>
+    <Container theme={theme} userStyle={style.missingData}>
+      <Tooltip style={props.style.tooltip} content={missingDataAsString}>
         Missing Data: {missingDataAsString}
-      </Container>
-    </Tooltip>
+      </Tooltip>
+    </Container>
   );
 };
+
+export const MissingDataCard = withTheme(MissingDataCardBase);

--- a/modules/core/src/components/declarative-ui/missing-data-card.js
+++ b/modules/core/src/components/declarative-ui/missing-data-card.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React from 'react';
+import {Tooltip} from '@streetscape.gl/monochrome';
+
+export const MissingDataCard = props => {
+  const {missingData} = props;
+  const missingDataAsString = missingData.join(', ');
+  const style = {
+    color: 'red',
+    padding: '10px 0',
+    maxWidth: '100%',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis'
+  };
+
+  return (
+    <div style={style}>
+      <Tooltip style={props.style.tooltip} content={missingDataAsString}>
+        Missing Data: {missingDataAsString}
+      </Tooltip>
+    </div>
+  );
+};

--- a/modules/core/src/components/declarative-ui/missing-data-card.js
+++ b/modules/core/src/components/declarative-ui/missing-data-card.js
@@ -18,25 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import React from 'react';
-import {Tooltip} from '@streetscape.gl/monochrome';
+import {evaluateStyle, Tooltip} from '@streetscape.gl/monochrome';
 import styled from '@emotion/styled';
 
-const WrapperComponent = styled.div(() => ({
+const Container = styled.div(props => ({
+  ...props.theme.__reset__,
   color: 'red',
   padding: '10px 0',
   width: '350px',
   whiteSpace: 'nowrap',
   overflow: 'hidden',
-  textOverflow: 'ellipsis'
+  textOverflow: 'ellipsis',
+  ...evaluateStyle(props.userStyle, props)
 }));
 
 export const MissingDataCard = props => {
-  const {missingData} = props;
+  const {missingData, theme, style} = props;
   const missingDataAsString = missingData.join(', ');
 
   return (
     <Tooltip style={props.style.tooltip} content={missingDataAsString}>
-      <WrapperComponent>Missing Data: {missingDataAsString}</WrapperComponent>
+      <Container theme={theme} userStyle={style.container}>
+        Missing Data: {missingDataAsString}
+      </Container>
     </Tooltip>
   );
 };

--- a/modules/core/src/components/declarative-ui/missing-data-card.js
+++ b/modules/core/src/components/declarative-ui/missing-data-card.js
@@ -38,7 +38,7 @@ export const MissingDataCard = props => {
 
   return (
     <Tooltip style={props.style.tooltip} content={missingDataAsString}>
-      <Container theme={theme} userStyle={style.container}>
+      <Container theme={theme} userStyle={style.missingData}>
         Missing Data: {missingDataAsString}
       </Container>
     </Tooltip>

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -25,6 +25,7 @@ import {MetricCard, MetricChart} from '@streetscape.gl/monochrome';
 import {DEFAULT_COLOR_SERIES} from './constants';
 import connectToLog from '../connect';
 import {getTimeSeries} from '../../utils/metrics-helper';
+import {MissingDataCard} from './missing-data-card';
 
 const defaultFormatValue = x => (Number.isFinite(x) ? x.toFixed(3) : String(x));
 
@@ -48,6 +49,7 @@ class XVIZMetricComponent extends PureComponent {
     streams: PropTypes.arrayOf(PropTypes.string).isRequired,
     title: PropTypes.string,
     description: PropTypes.string,
+    missingData: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
     currentTime: PropTypes.number,
@@ -125,13 +127,21 @@ class XVIZMetricComponent extends PureComponent {
       formatValue,
       horizontalGridLines,
       verticalGridLines,
-      getColor
+      getColor,
+      streams
     } = this.props;
     const isLoading = currentTime == null; /* eslint-disable-line no-eq-null, eqeqeq */
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
+    const {timeSeries} = this.state;
+    const missingStreams = streams.filter(streamToDisplay => !timeSeries.data[streamToDisplay]);
+
+    /*
+      TODO: MetricCard will not display children if isLoading === true
+    */
 
     return (
       <MetricCard title={title} description={description} isLoading={isLoading} style={style}>
+        {missingStreams.length && <MissingDataCard style={style} missingData={missingStreams} />}
         {!isLoading && (
           <MetricChart
             {...this.state.timeSeries}

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -49,7 +49,6 @@ class XVIZMetricComponent extends PureComponent {
     streams: PropTypes.arrayOf(PropTypes.string).isRequired,
     title: PropTypes.string,
     description: PropTypes.string,
-    missingData: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
     currentTime: PropTypes.number,
@@ -136,9 +135,9 @@ class XVIZMetricComponent extends PureComponent {
     return (
       <MetricCard title={title} description={description} isLoading={false} style={style}>
         <>
-          {missingStreams.length !== 0 ? (
+          {missingStreams.length > 0 && (
             <MissingDataCard style={style} missingData={missingStreams} />
-          ) : null}
+          )}
           {isLoading ? (
             <Spinner />
           ) : (

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -77,6 +77,7 @@ class XVIZMetricComponent extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      missingStreams: [],
       timeSeries: this._getTimeSeries(props)
     };
   }
@@ -91,6 +92,12 @@ class XVIZMetricComponent extends PureComponent {
         timeSeries: this._getTimeSeries(nextProps)
       });
     }
+
+    const {timeSeries} = this.state;
+    const missingStreams = this.props.streams.filter(
+      streamToDisplay => !timeSeries.data[streamToDisplay]
+    );
+    this.setState({missingStreams});
   }
 
   _getTimeSeries(props) {
@@ -127,13 +134,12 @@ class XVIZMetricComponent extends PureComponent {
       formatValue,
       horizontalGridLines,
       verticalGridLines,
-      getColor,
-      streams
+      getColor
     } = this.props;
     const isLoading = currentTime == null; /* eslint-disable-line no-eq-null, eqeqeq */
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
-    const {timeSeries} = this.state;
-    const missingStreams = streams.filter(streamToDisplay => !timeSeries.data[streamToDisplay]);
+    // const {timeSeries} = this.state;
+    const {missingStreams} = this.state; // = streams.filter(streamToDisplay => !timeSeries.data[streamToDisplay]);
 
     return (
       <MetricCard title={title} description={description} isLoading={false} style={style}>

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -138,8 +138,7 @@ class XVIZMetricComponent extends PureComponent {
     } = this.props;
     const isLoading = currentTime == null; /* eslint-disable-line no-eq-null, eqeqeq */
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
-    // const {timeSeries} = this.state;
-    const {missingStreams} = this.state; // = streams.filter(streamToDisplay => !timeSeries.data[streamToDisplay]);
+    const {missingStreams} = this.state;
 
     return (
       <MetricCard title={title} description={description} isLoading={false} style={style}>

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -77,7 +77,6 @@ class XVIZMetricComponent extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      missingStreams: [],
       timeSeries: this._getTimeSeries(props)
     };
   }
@@ -92,12 +91,6 @@ class XVIZMetricComponent extends PureComponent {
         timeSeries: this._getTimeSeries(nextProps)
       });
     }
-
-    const {timeSeries} = this.state;
-    const missingStreams = this.props.streams.filter(
-      streamToDisplay => !timeSeries.data[streamToDisplay]
-    );
-    this.setState({missingStreams});
   }
 
   _getTimeSeries(props) {
@@ -138,7 +131,7 @@ class XVIZMetricComponent extends PureComponent {
     } = this.props;
     const isLoading = currentTime == null; /* eslint-disable-line no-eq-null, eqeqeq */
     const timeDomain = Number.isFinite(startTime) ? [startTime, endTime] : null;
-    const {missingStreams} = this.state;
+    const {missingStreams} = this.state.timeSeries;
 
     return (
       <MetricCard title={title} description={description} isLoading={false} style={style}>

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -20,7 +20,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {MetricCard, MetricChart} from '@streetscape.gl/monochrome';
+import {MetricCard, MetricChart, Spinner} from '@streetscape.gl/monochrome';
 
 import {DEFAULT_COLOR_SERIES} from './constants';
 import connectToLog from '../connect';
@@ -135,14 +135,14 @@ class XVIZMetricComponent extends PureComponent {
     const {timeSeries} = this.state;
     const missingStreams = streams.filter(streamToDisplay => !timeSeries.data[streamToDisplay]);
 
-    /*
-      TODO: MetricCard will not display children if isLoading === true
-    */
-
     return (
-      <MetricCard title={title} description={description} isLoading={isLoading} style={style}>
-        {missingStreams.length && <MissingDataCard style={style} missingData={missingStreams} />}
-        {!isLoading && (
+      <MetricCard title={title} description={description} isLoading={false} style={style}>
+        {missingStreams.length !== 0 ? (
+          <MissingDataCard style={style} missingData={missingStreams} />
+        ) : null}
+        {isLoading ? (
+          <Spinner />
+        ) : (
           <MetricChart
             {...this.state.timeSeries}
             getColor={getColor}

--- a/modules/core/src/components/declarative-ui/xviz-metric.js
+++ b/modules/core/src/components/declarative-ui/xviz-metric.js
@@ -137,30 +137,32 @@ class XVIZMetricComponent extends PureComponent {
 
     return (
       <MetricCard title={title} description={description} isLoading={false} style={style}>
-        {missingStreams.length !== 0 ? (
-          <MissingDataCard style={style} missingData={missingStreams} />
-        ) : null}
-        {isLoading ? (
-          <Spinner />
-        ) : (
-          <MetricChart
-            {...this.state.timeSeries}
-            getColor={getColor}
-            highlightX={currentTime}
-            width={width}
-            height={height}
-            style={style}
-            xTicks={xTicks}
-            yTicks={yTicks}
-            formatXTick={formatXTick}
-            formatYTick={formatYTick}
-            formatValue={formatValue}
-            xDomain={timeDomain}
-            onClick={this._onClick}
-            horizontalGridLines={horizontalGridLines}
-            verticalGridLines={verticalGridLines}
-          />
-        )}
+        <>
+          {missingStreams.length !== 0 ? (
+            <MissingDataCard style={style} missingData={missingStreams} />
+          ) : null}
+          {isLoading ? (
+            <Spinner />
+          ) : (
+            <MetricChart
+              {...this.state.timeSeries}
+              getColor={getColor}
+              highlightX={currentTime}
+              width={width}
+              height={height}
+              style={style}
+              xTicks={xTicks}
+              yTicks={yTicks}
+              formatXTick={formatXTick}
+              formatYTick={formatYTick}
+              formatValue={formatValue}
+              xDomain={timeDomain}
+              onClick={this._onClick}
+              horizontalGridLines={horizontalGridLines}
+              verticalGridLines={verticalGridLines}
+            />
+          )}
+        </>
       </MetricCard>
     );
   }

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -195,9 +195,9 @@ class XVIZPlotComponent extends PureComponent {
     return (
       <MetricCard title={title} description={description} style={style} isLoading={false}>
         <>
-          {missingStreams.length !== 0 ? (
+          {missingStreams.length > 0 && (
             <MissingDataCard style={style} missingData={missingStreams} />
-          ) : null}
+          )}
           {dataProps.isLoading ? (
             <Spinner />
           ) : (

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -74,10 +74,15 @@ class XVIZPlotComponent extends PureComponent {
 
   state = {
     independentVariable: null,
-    dependentVariables: {}
+    dependentVariables: {},
+    missingStreams: []
   };
 
   componentWillReceiveProps(nextProps) {
+    const {dependentVariables} = this.state;
+    const missingStreams = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
+    this.setState({missingStreams});
+
     if (!nextProps.variables) {
       this.setState({independentVariable: null});
       return;
@@ -187,8 +192,8 @@ class XVIZPlotComponent extends PureComponent {
     } = this.props;
 
     const dataProps = this._extractDataProps();
-    const {dependentVariables} = this.state;
-    const missingStreams = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
+    // const {dependentVariables} = this.state;
+    const {missingStreams} = this.state; // = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
 
     return (
       <MetricCard title={title} description={description} style={style} isLoading={false}>

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -20,7 +20,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {MetricCard, MetricChart} from '@streetscape.gl/monochrome';
+import {MetricCard, MetricChart, Spinner} from '@streetscape.gl/monochrome';
 
 import {DEFAULT_COLOR_SERIES} from './constants';
 import connectToLog from '../connect';
@@ -189,39 +189,32 @@ class XVIZPlotComponent extends PureComponent {
     const dataProps = this._extractDataProps();
     const {dependentVariables} = this.state;
     const missingStreams = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
-    /*
-      TODO: Add missing independent variables to missingStreams above
-      independent variables might just be timestamps.. don't need to know about each one?
-    */
-
-    /*
-      TODO: MetricCard will not display children if isLoading === true
-    */
 
     return (
-      <MetricCard
-        title={title}
-        description={description}
-        style={style}
-        isLoading={dataProps.isLoading}
-      >
-        {missingStreams.length && <MissingDataCard style={style} missingData={missingStreams} />}
-        <MetricChart
-          {...dataProps}
-          getColor={getColor}
-          highlightX={0}
-          width={width}
-          height={height}
-          style={style}
-          xTicks={xTicks}
-          yTicks={yTicks}
-          formatXTick={formatXTick}
-          formatYTick={formatYTick}
-          onClick={this._onClick}
-          formatTitle={this._formatTitle}
-          horizontalGridLines={horizontalGridLines}
-          verticalGridLines={verticalGridLines}
-        />
+      <MetricCard title={title} description={description} style={style} isLoading={false}>
+        {missingStreams.length !== 0 ? (
+          <MissingDataCard style={style} missingData={missingStreams} />
+        ) : null}
+        {dataProps.isLoading ? (
+          <Spinner />
+        ) : (
+          <MetricChart
+            {...dataProps}
+            getColor={getColor}
+            highlightX={0}
+            width={width}
+            height={height}
+            style={style}
+            xTicks={xTicks}
+            yTicks={yTicks}
+            formatXTick={formatXTick}
+            formatYTick={formatYTick}
+            onClick={this._onClick}
+            formatTitle={this._formatTitle}
+            horizontalGridLines={horizontalGridLines}
+            verticalGridLines={verticalGridLines}
+          />
+        )}
       </MetricCard>
     );
   }

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -24,6 +24,7 @@ import {MetricCard, MetricChart} from '@streetscape.gl/monochrome';
 
 import {DEFAULT_COLOR_SERIES} from './constants';
 import connectToLog from '../connect';
+import {MissingDataCard} from './missing-data-card';
 
 const GET_X = d => d[0];
 const GET_Y = d => d[1];
@@ -49,6 +50,7 @@ class XVIZPlotComponent extends PureComponent {
     description: PropTypes.string,
     independentVariable: PropTypes.string,
     dependentVariables: PropTypes.arrayOf(PropTypes.string),
+    missingData: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
     metadata: PropTypes.object,
@@ -185,6 +187,16 @@ class XVIZPlotComponent extends PureComponent {
     } = this.props;
 
     const dataProps = this._extractDataProps();
+    const {dependentVariables} = this.state;
+    const missingStreams = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
+    /*
+      TODO: Add missing independent variables to missingStreams above
+      independent variables might just be timestamps.. don't need to know about each one?
+    */
+
+    /*
+      TODO: MetricCard will not display children if isLoading === true
+    */
 
     return (
       <MetricCard
@@ -193,6 +205,7 @@ class XVIZPlotComponent extends PureComponent {
         style={style}
         isLoading={dataProps.isLoading}
       >
+        {missingStreams.length && <MissingDataCard style={style} missingData={missingStreams} />}
         <MetricChart
           {...dataProps}
           getColor={getColor}

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -192,8 +192,7 @@ class XVIZPlotComponent extends PureComponent {
     } = this.props;
 
     const dataProps = this._extractDataProps();
-    // const {dependentVariables} = this.state;
-    const {missingStreams} = this.state; // = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
+    const {missingStreams} = this.state;
 
     return (
       <MetricCard title={title} description={description} style={style} isLoading={false}>

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -192,29 +192,31 @@ class XVIZPlotComponent extends PureComponent {
 
     return (
       <MetricCard title={title} description={description} style={style} isLoading={false}>
-        {missingStreams.length !== 0 ? (
-          <MissingDataCard style={style} missingData={missingStreams} />
-        ) : null}
-        {dataProps.isLoading ? (
-          <Spinner />
-        ) : (
-          <MetricChart
-            {...dataProps}
-            getColor={getColor}
-            highlightX={0}
-            width={width}
-            height={height}
-            style={style}
-            xTicks={xTicks}
-            yTicks={yTicks}
-            formatXTick={formatXTick}
-            formatYTick={formatYTick}
-            onClick={this._onClick}
-            formatTitle={this._formatTitle}
-            horizontalGridLines={horizontalGridLines}
-            verticalGridLines={verticalGridLines}
-          />
-        )}
+        <>
+          {missingStreams.length !== 0 ? (
+            <MissingDataCard style={style} missingData={missingStreams} />
+          ) : null}
+          {dataProps.isLoading ? (
+            <Spinner />
+          ) : (
+            <MetricChart
+              {...dataProps}
+              getColor={getColor}
+              highlightX={0}
+              width={width}
+              height={height}
+              style={style}
+              xTicks={xTicks}
+              yTicks={yTicks}
+              formatXTick={formatXTick}
+              formatYTick={formatYTick}
+              onClick={this._onClick}
+              formatTitle={this._formatTitle}
+              horizontalGridLines={horizontalGridLines}
+              verticalGridLines={verticalGridLines}
+            />
+          )}
+        </>
       </MetricCard>
     );
   }

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -75,14 +75,10 @@ class XVIZPlotComponent extends PureComponent {
   state = {
     independentVariable: null,
     dependentVariables: {},
-    missingStreams: []
+    missingStreams: this.props.dependentVariables
   };
 
   componentWillReceiveProps(nextProps) {
-    const {dependentVariables} = this.state;
-    const missingStreams = Object.keys(dependentVariables).filter(dv => !dependentVariables[dv]);
-    this.setState({missingStreams});
-
     if (!nextProps.variables) {
       this.setState({independentVariable: null});
       return;
@@ -114,7 +110,10 @@ class XVIZPlotComponent extends PureComponent {
     if (independentVariableChanged || dependentVariablesChanged) {
       this.setState({
         independentVariable,
-        dependentVariables: {...this.state.dependentVariables, ...updatedDependentVariable}
+        dependentVariables: {...this.state.dependentVariables, ...updatedDependentVariable},
+        missingStreams: Object.keys(updatedDependentVariable).filter(
+          dv => !updatedDependentVariable[dv]
+        )
       });
     }
   }

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -50,7 +50,6 @@ class XVIZPlotComponent extends PureComponent {
     description: PropTypes.string,
     independentVariable: PropTypes.string,
     dependentVariables: PropTypes.arrayOf(PropTypes.string),
-    missingData: PropTypes.arrayOf(PropTypes.string),
 
     // From connected log
     metadata: PropTypes.object,

--- a/modules/core/src/utils/metrics-helper.js
+++ b/modules/core/src/utils/metrics-helper.js
@@ -51,7 +51,8 @@ function getTimeSeriesForStream(streamName, metadata, stream, target) {
 export function getTimeSeries({metadata = {}, streamNames, streams}) {
   const timeSeries = {
     isLoading: true,
-    data: {}
+    data: {},
+    missingStreams: []
   };
   for (const streamName of streamNames) {
     // ui configuration for this stream
@@ -61,6 +62,10 @@ export function getTimeSeries({metadata = {}, streamNames, streams}) {
       getTimeSeriesForStream(streamName, streamMetadata, stream, timeSeries);
     }
   }
+
+  timeSeries.missingStreams = streamNames.filter(
+    streamToDisplay => !timeSeries.data[streamToDisplay]
+  );
 
   return timeSeries;
 }


### PR DESCRIPTION
This PR addresses [issue 344](https://github.com/uber/streetscape.gl/issues/344). 

- Adds in a Missing Data component to let users know which information is missing
- Missing data has a Tooltip and ellipsis applied to it
- Moves the conditional logic of displaying a loading spinner out of Monochrome (MetricCard) and into the XVIZ layer 
- Bumps up the Monochrome version to beta.4

![missing_data](https://user-images.githubusercontent.com/9030131/60978415-1984bb00-a2ff-11e9-9897-0d3e2b96f8cf.png)
