### PR TITLE
Protobuf related changes due to using protobufjs objects

### DIFF
--- a/docs/api-reference/connect-to-log.md
+++ b/docs/api-reference/connect-to-log.md
@@ -1,8 +1,8 @@
 # connectToLog
 
 Wraps a React component in a
-[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when a
-[XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
+[higher-order component](https://reactjs.org/docs/higher-order-components.html) that rerenders when
+a [XVIZLoader](/docs/api-reference/xviz-loader-interface.md) updates.
 
 ```jsx
 // some-container.js

--- a/modules/core/src/components/declarative-ui/xviz-panel.js
+++ b/modules/core/src/components/declarative-ui/xviz-panel.js
@@ -86,8 +86,9 @@ class XVIZPanelComponent extends PureComponent {
 
 const getLogState = (log, ownProps) => {
   const metadata = log.getMetadata();
+  const panel = metadata && metadata.ui_config && metadata.ui_config[ownProps.name];
   return {
-    uiConfig: metadata && metadata.ui_config && metadata.ui_config[ownProps.name]
+    uiConfig: panel.config || panel
   };
 };
 

--- a/modules/core/src/components/declarative-ui/xviz-plot.js
+++ b/modules/core/src/components/declarative-ui/xviz-plot.js
@@ -135,9 +135,14 @@ class XVIZPlotComponent extends PureComponent {
     const x = independentVariable[0].values;
 
     return variable.map(({id, values}) => {
+      // TypeArray.map() cannot return an array as the result so construct
+      // a new Array explicitly
+      const valueTuple = new Array(values.length);
+      values.forEach((v, k) => (valueTuple[k] = [x[k], v]));
+
       return {
         id,
-        values: values.map((v, k) => [x[k], v])
+        values: valueTuple
       };
     });
   }

--- a/modules/core/src/components/declarative-ui/xviz-table.js
+++ b/modules/core/src/components/declarative-ui/xviz-table.js
@@ -88,7 +88,9 @@ class XVIZTableComponent extends PureComponent {
       };
       rowIds[node.id] = row;
 
-      if (node.parent === undefined) {
+      // Validate the property is on the instance, and not just in the
+      // prototype chain. This comes from how protobuf.js implements messages
+      if (!node.hasOwnProperty('parent') || node.parent === undefined) {
         rows.push(row);
       } else {
         const parentRow = rowIds[node.parent];

--- a/modules/core/src/utils/transform.js
+++ b/modules/core/src/utils/transform.js
@@ -60,7 +60,7 @@ export function resolveCoordinateTransform(frame, streamMetadata = {}, getTransf
     // TODO - remove when builder updates
     streamTransform = new Pose(pose).getTransformationMatrix();
   }
-  if (streamTransform) {
+  if (streamTransform && streamTransform.length > 0) {
     modelMatrix = modelMatrix
       ? new Matrix4(modelMatrix).multiplyRight(streamTransform)
       : streamTransform;


### PR DESCRIPTION
protobuf.js instances use prototype construction and properties will be searched up the prototype chain.  We must add validation to ensure the property is on the instance and not the prototype.