### PR TITLE
Fix bug where panel is undef on first render due to no metadata

### DIFF
--- a/modules/core/src/components/declarative-ui/xviz-panel.js
+++ b/modules/core/src/components/declarative-ui/xviz-panel.js
@@ -87,8 +87,10 @@ class XVIZPanelComponent extends PureComponent {
 const getLogState = (log, ownProps) => {
   const metadata = log.getMetadata();
   const panel = metadata && metadata.ui_config && metadata.ui_config[ownProps.name];
+  // If we have a panel we want to use the 'config', else we just return the panel
+  // which is either the 'beta' structure for UI or undefined
   return {
-    uiConfig: panel.config || panel
+    uiConfig: (panel && panel.config) || panel
   };
 };
 


### PR DESCRIPTION
I'm validating why local testing didn't show this.  Possible metadata was present by the time this rendered locally?