### PR TITLE
Various fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 **/dist*/**/*.js
 *.min.js
-modules/monochrome/storybook-static/**/*.js
+storybook-static/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/dist*/**/*.js
 *.min.js
+modules/monochrome/storybook-static/**/*.js

--- a/examples/website-demo/src/custom-styles.js
+++ b/examples/website-demo/src/custom-styles.js
@@ -146,14 +146,14 @@ export const HELP_BUTTON_STYLE = {
 };
 
 const PRIMITIVE_TYPE_TO_ICON = {
-  point: '\\e90c',
-  circle: '\\e907',
-  image: '\\e90a',
-  polyline: '\\e90e',
-  polygon: '\\e90d',
-  float: '\\e917',
-  text: '\\e913',
-  group: '\\e909'
+  POINT: '\\e90c',
+  CIRCLE: '\\e907',
+  IMAGE: '\\e90a',
+  POLYLINE: '\\e90e',
+  POLYGON: '\\e90d',
+  FLOAT: '\\e917',
+  TEXT: '\\e913',
+  GROUP: '\\e909'
 };
 
 export const STREAM_SETTINGS_STYLE = {
@@ -182,12 +182,12 @@ export const STREAM_SETTINGS_STYLE = {
   badge: props => ({
     order: -1,
     '&:before':
-      props.type in PRIMITIVE_TYPE_TO_ICON
+      props.type.toUpperCase() in PRIMITIVE_TYPE_TO_ICON
         ? {
             fontFamily: 'streetscape',
             fontSize: 16,
             paddingRight: 12,
-            content: `"${PRIMITIVE_TYPE_TO_ICON[props.type]}"`
+            content: `"${PRIMITIVE_TYPE_TO_ICON[props.type.toUpperCase()]}"`
           }
         : {
             content: '""'

--- a/examples/xviz-playground/package.json
+++ b/examples/xviz-playground/package.json
@@ -20,6 +20,7 @@
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/preset-flow": "^7.7.4",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.0",
     "source-map-loader": "^0.2.3",

--- a/examples/xviz-playground/webpack.config.js
+++ b/examples/xviz-playground/webpack.config.js
@@ -23,7 +23,7 @@ const {resolve} = require('path');
 const webpack = require('webpack');
 
 const BABEL_CONFIG = {
-  presets: ['@babel/preset-env', '@babel/preset-react'],
+  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-flow'],
   plugins: ['@babel/proposal-class-properties']
 };
 

--- a/modules/core/src/utils/transform.js
+++ b/modules/core/src/utils/transform.js
@@ -75,7 +75,7 @@ export function resolveCoordinateTransform(
   streamMetadata = {},
   getTransformMatrix
 ) {
-  const {origin, links, streams, transforms = {}, vehicleRelativeTransform} = frame;
+  const {origin, links = {}, streams, transforms = {}, vehicleRelativeTransform} = frame;
   const {coordinate, transform, pose} = streamMetadata;
 
   let coordinateSystem = COORDINATE_SYSTEM.METER_OFFSETS;


### PR DESCRIPTION
- ignore lint on some vendor files
- website-demo: change strings to conform to spec as uppercase
- playground: fix build dependency on @babel/preset-flow
- core: fix for missing 'links' in transform path