### PR TITLE
Parse video frames from stream

### DIFF
--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -109,6 +109,11 @@ export default class XVIZLoaderInterface {
         this.emit('update', message);
         break;
 
+      case LOG_STREAM_MESSAGE.VIDEO_FRAME:
+        this._onXVIZVideoFrame(message);
+        this.emit('update', message);
+        break;
+
       case LOG_STREAM_MESSAGE.DONE:
         this.emit('finish', message);
         break;
@@ -287,6 +292,28 @@ export default class XVIZLoaderInterface {
     }
 
     return bufferUpdated;
+  }
+
+  _onXVIZVideoFrame(message) {
+    const timeSlice = {
+      timestamp: message.timestamp,
+      streams: {
+        [message.stream]: {
+          time: message.timestamp,
+          images: [
+            {
+              type: 'image',
+              height_px: null,
+              width_px: null,
+              imageType: message.imageType,
+              imageData: message.imageData
+            }
+          ]
+        }
+      }
+    };
+
+    return this._onXVIZTimeslice(timeSlice);
   }
 
   _getDataByStream() {


### PR DESCRIPTION
This adds basic parsing of video frame messages from log streams.

Before, these messages were dropped making them inaccessible to any camera `XVIZPanel`. You still need to define the right UI config in the XVIZ metadata for the panel to pick it up.