### PR TITLE
DYNAMIC_STREAM_METADATA should be decoupled from streamSettings

### DIFF
--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -279,7 +279,7 @@ export default class XVIZLoaderInterface {
         streamsMetadata[streamName] = timeslice.streams[streamName].__metadata;
 
         // Add new stream name to stream settings (default on)
-        if (!(streamName in streamSettings)) {
+        if (streamSettings && !(streamName in streamSettings)) {
           streamSettings[streamName] = true;
         }
       }


### PR DESCRIPTION
Reasoning:
DYNAMIC_STREAM_METADATA configuration should be decoupled from streamSettings.


Current behavior:
when DYNAMIC_STREAM_METADATA is set to true, and streamSettings is not set, the _onXVIZTimeslice throws an error 