### PR TITLE
New loader interfaces

### DIFF
--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -27,6 +27,8 @@ export {default as XVIZLayer} from './layers/xviz-layer';
 
 // COMPONENTS
 
+export {default as connect} from './components/connect';
+// Keep the old export name "connectToLog" for backwards compatibility.
 export {default as connectToLog} from './components/connect';
 
 export {default as LogViewer} from './components/log-viewer';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -54,6 +54,8 @@ export {mergeXVIZStyles} from './utils/style';
 // Constants
 export {COORDINATE, VIEW_MODE} from './constants';
 
+export {default as _LoaderInterface} from './loaders/loader-interface';
+export {default as _PlayableLoaderInterface} from './loaders/playable-loader-interface';
 export {default as _XVIZLoaderInterface} from './loaders/xviz-loader-interface';
 export {default as XVIZStreamLoader} from './loaders/xviz-stream-loader';
 export {default as XVIZLiveLoader} from './loaders/xviz-live-loader';

--- a/modules/core/src/loaders/loader-interface.js
+++ b/modules/core/src/loaders/loader-interface.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default class LoaderInterface {
+  constructor() {
+    this.listeners = [];
+    this.state = {};
+    this._updates = 0;
+    this._version = 0;
+    this._updateTimer = null;
+  }
+
+  subscribe(instance) {
+    this.listeners.push(instance);
+  }
+
+  unsubscribe(instance) {
+    const index = this.listeners.findIndex(o => o === instance);
+    if (index >= 0) {
+      this.listeners.splice(index, 1);
+    }
+  }
+
+  get(key) {
+    return this.state[key];
+  }
+
+  set(key, value) {
+    if (this.state[key] !== value) {
+      this.state[key] = value;
+      this._version++;
+      if (!this._updateTimer) {
+        /* global requestAnimationFrame */
+        this._updateTimer = requestAnimationFrame(this._update);
+      }
+    }
+  }
+
+  _update = () => {
+    this._updateTimer = null;
+    this.listeners.forEach(o => o(this._version));
+  };
+
+  _bumpDataVersion() {
+    this._updates++;
+    this.set('dataVersion', this._updates);
+  }
+}

--- a/modules/core/src/loaders/loader-interface.js
+++ b/modules/core/src/loaders/loader-interface.js
@@ -18,6 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+/**
+ * This class defines the interface for Loader classes. A Loader is factually
+ * a store holding state for connected components. We call the subclasses of this
+ * interface "Loaders" and not simply "Stores" because they are is usually also
+ * responsible for loading data in addition of storing it.
+ *
+ * The pattern of a Loader is very similar to the Redux store.
+ * We provide a "connect()" High Order Component (H.O.C.) to connect React
+ * components to Loader instances. Connected components will react to the loader's
+ * state changes, very much like React components react to the Redux's store state
+ * changes when they are connected it via the Redux connect() HOC.
+ *
+ * @example
+ *
+ * // Define and instantiate a new loader.
+ * class MyLoader extends LoaderInterface { ... }
+ * const loader = new MyLoader(...opts);
+ *
+ * // Create a new component that will connect to the loader state.
+ * const MyComponent = props => <div>{props.foo}:{props.bar}</div>;
+ *
+ * // Connect component to the loader.
+ * import {connect} from 'streetscape.gl';
+ * const mapStateToProps = loader => ({
+ *     foo: loader.get('foo'),
+ *     bar: loader.get('bar')
+ * });
+ * const MyConnectedComponent = connect(mapStateToProps, MyComponent);
+ *
+ * // Render connected component somewhere and feed it the loader. It will
+ * // react to the loader state changes.
+ * <MyConnectedComponent loader={loader} />
+ */
 export default class LoaderInterface {
   constructor() {
     this.listeners = [];

--- a/modules/core/src/loaders/playable-loader-interface.js
+++ b/modules/core/src/loaders/playable-loader-interface.js
@@ -20,6 +20,10 @@
 
 import LoaderInterface from './loader-interface';
 
+/**
+ * This interfaces exposes the methods required for compatibility with
+ * the PlaybackControl component - that enables scrubbing through a buffered log.
+ */
 export default class PlayableLoaderInterface extends LoaderInterface {
   /**
    * Seek to a given timestamp.

--- a/modules/core/src/loaders/playable-loader-interface.js
+++ b/modules/core/src/loaders/playable-loader-interface.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import LoaderInterface from './loader-interface';
+
+export default class PlayableLoaderInterface extends LoaderInterface {
+  /**
+   * Seek to a given timestamp.
+   *
+   * @param {Number} timestamp
+   */
+  seek(timestamp) {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Play the log.
+   */
+  play() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Pause the log.
+   */
+  pause() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns the current timestamp in seconds.
+   */
+  getCurrentTime() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns the current look ahead offset in seconds.
+   */
+  getLookAhead() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Set the look ahead offset in seconds.
+   * This is used to retrieve a slice from the future states for display.
+   *
+   * @param {Number} lookAhead - look ahead in seconds.
+   */
+  setLookAhead(lookAhead) {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns the start timestamp of the log.
+   */
+  getLogStartTime() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns the end timestamp of the log.
+   */
+  getLogEndTime() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns the loaded time ranges of the buffer, as an array of `[start, end]` timestamps.
+   */
+  getBufferedTimeRanges() {
+    throw new Error('Not implemented');
+  }
+}

--- a/modules/core/src/loaders/xviz-loader-interface.js
+++ b/modules/core/src/loaders/xviz-loader-interface.js
@@ -21,21 +21,17 @@
 import {getXVIZConfig, StreamSynchronizer, LOG_STREAM_MESSAGE} from '@xviz/parser';
 import {clamp} from 'math.gl';
 
+import PlayableLoaderInterface from './playable-loader-interface';
 import createSelector from '../utils/create-selector';
 import stats from '../utils/stats';
 
 /* eslint-disable callback-return */
-export default class XVIZLoaderInterface {
+export default class XVIZLoaderInterface extends PlayableLoaderInterface {
   constructor(options = {}) {
+    super();
     this.options = options;
     this._debug = options.debug || (() => {});
     this.callbacks = {};
-
-    this.listeners = [];
-    this.state = {};
-    this._updates = 0;
-    this._version = 0;
-    this._updateTimer = null;
   }
 
   /* Event types:
@@ -69,32 +65,6 @@ export default class XVIZLoaderInterface {
       }
     }
     stats.get(`loader-${eventType}`).incrementCount();
-  }
-
-  subscribe(instance) {
-    this.listeners.push(instance);
-  }
-
-  unsubscribe(instance) {
-    const index = this.listeners.findIndex(o => o === instance);
-    if (index >= 0) {
-      this.listeners.splice(index, 1);
-    }
-  }
-
-  get(key) {
-    return this.state[key];
-  }
-
-  set(key, value) {
-    if (this.state[key] !== value) {
-      this.state[key] = value;
-      this._version++;
-      if (!this._updateTimer) {
-        /* global requestAnimationFrame */
-        this._updateTimer = requestAnimationFrame(this._update);
-      }
-    }
   }
 
   onXVIZMessage = message => {
@@ -232,17 +202,6 @@ export default class XVIZLoaderInterface {
       return null;
     }
   );
-
-  /* Private actions */
-  _update = () => {
-    this._updateTimer = null;
-    this.listeners.forEach(o => o(this._version));
-  };
-
-  _bumpDataVersion() {
-    this._updates++;
-    this.set('dataVersion', this._updates);
-  }
 
   /* Subclass hooks */
 


### PR DESCRIPTION
Split up `XVIZLoaderInterface` into sub classes to introduce more modular interfaces.
* `LoaderInterface`: responsible for holding state of the loaded data.
* `PlayableLoaderInterface`: exposes the methods required for compatibility with the `PlaybackControl` streetscape component - that enables scrubbing through a buffered log.
```
/**
 * This class defines the interface for Loader classes. A Loader is factually
 * a store holding state for connected components. We call the subclasses of this
 * interface "Loaders" and not simply "Stores" because they are is usually also
 * responsible for loading data in addition of storing it.
 *
 * The pattern of a Loader is very similar to the Redux store.
 * We provide a "connect()" High Order Component (H.O.C.) to connect React
 * components to Loader instances. Connected components will react to the loader's
 * state changes, very much like React components react to the Redux's store state
 * changes when they are connected it via the Redux connect() HOC.
 **/
```
Example:
```jsx
// Define and instantiate a new loader.
class MyLoader extends LoaderInterface {
    // Some arbitrary internal method that will store the loaded data
    _onMessage(msg) {
       this.set('foo', msg.foo);
       this.set('bar', msg.bar);
   }
}
const loader = new MyLoader(...opts);

// Create a new component that will connect to the loader state.
const MyComponent = props => <div>{props.foo}:{props.bar}</div>;

// Connect component to the loader.
import {connect} from 'streetscape.gl';
const mapStateToProps = loader => ({
     foo: loader.get('foo'),
     bar: loader.get('bar')
 });
const MyConnectedComponent = connect(mapStateToProps, MyComponent);

// Render connected component somewhere and feed it the loader. It will
// react to the loader state changes.
<MyConnectedComponent loader={loader} />
```