### PR TITLE
Fix right click in _onLayerClick

### DIFF
--- a/modules/core/src/components/log-viewer/core-3d-viewer.js
+++ b/modules/core/src/components/log-viewer/core-3d-viewer.js
@@ -191,7 +191,7 @@ export default class Core3DViewer extends PureComponent {
   };
 
   _onLayerClick = (info, evt) => {
-    const isRightClick = evt.which === 3;
+    const isRightClick = evt.rightButton;
 
     if (isRightClick) {
       this.props.onContextMenu(info, evt);


### PR DESCRIPTION
The `evt` variable has a boolean attribute `rightButton` indicating whether it is a right click or not.

The current code `evt.which === 3` does not seem to work.